### PR TITLE
Implement password reset page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Reset de Senha
+
+1. Clique em **Esqueceu sua senha?** na tela de login e informe seu email.
+2. Você receberá um link que redireciona para a página de redefinição.
+3. Escolha a nova senha e faça login novamente.

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs"
+import { cookies } from "next/headers"
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url)
+  const code = requestUrl.searchParams.get("code")
+  const next = requestUrl.searchParams.get("next") ?? "/"
+
+  if (code) {
+    const supabase = createRouteHandlerClient({ cookies })
+    await supabase.auth.exchangeCodeForSession(code)
+  }
+
+  return NextResponse.redirect(`${requestUrl.origin}${next}`)
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -73,7 +73,7 @@ export default function ForgotPasswordPage() {
             <CheckCircle2 className="h-4 w-4 text-primary" />
             <AlertTitle>Email enviado!</AlertTitle>
             <AlertDescription>
-              Enviamos um email com instruções para recuperar sua senha. Verifique sua caixa de entrada.
+              Enviamos um email com um link para redefinir sua senha. Após clicar, você será direcionado para escolher a nova senha.
             </AlertDescription>
           </Alert>
         )}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { z } from "zod"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Loader2, AlertCircle, CheckCircle2 } from "lucide-react"
+
+const formSchema = z
+  .object({
+    password: z.string().min(6, { message: "A senha deve ter pelo menos 6 caracteres" }),
+    confirmPassword: z.string().min(6, { message: "Confirme a nova senha" }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "As senhas não coincidem",
+    path: ["confirmPassword"],
+  })
+
+type FormValues = z.infer<typeof formSchema>
+
+export default function ResetPasswordPage() {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const router = useRouter()
+  const supabase = createClientComponentClient()
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
+  })
+
+  const onSubmit = async (values: FormValues) => {
+    setIsSubmitting(true)
+    setError(null)
+    setSuccess(false)
+
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({
+        password: values.password,
+      })
+
+      if (updateError) {
+        setError(updateError.message)
+      } else {
+        setSuccess(true)
+        form.reset()
+        setTimeout(() => {
+          router.push("/login?message=Senha atualizada com sucesso! Faça login.")
+        }, 3000)
+      }
+    } catch (e) {
+      setError("Ocorreu um erro ao atualizar sua senha.")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="container py-8 md:py-12">
+      <div className="max-w-md mx-auto">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold tracking-tight mb-2">Redefinir Senha</h1>
+          <p className="text-muted-foreground">Escolha uma nova senha para sua conta.</p>
+        </div>
+
+        {error && (
+          <Alert variant="destructive" className="mb-6">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Erro</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {success && (
+          <Alert className="mb-6 bg-primary/20">
+            <CheckCircle2 className="h-4 w-4 text-primary" />
+            <AlertTitle>Senha atualizada!</AlertTitle>
+            <AlertDescription>
+              Sua senha foi redefinida com sucesso. Você será redirecionado para o login.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Definir Nova Senha</CardTitle>
+            <CardDescription>Digite a nova senha desejada.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nova Senha</FormLabel>
+                      <FormControl>
+                        <Input type="password" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="confirmPassword"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Confirmar Senha</FormLabel>
+                      <FormControl>
+                        <Input type="password" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <Button type="submit" className="w-full" disabled={isSubmitting}>
+                  {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {isSubmitting ? "Salvando..." : "Redefinir Senha"}
+                </Button>
+              </form>
+            </Form>
+          </CardContent>
+          <CardFooter className="flex justify-center">
+            <div className="text-sm text-center">
+              <Link href="/login" className="text-primary hover:underline">
+                Voltar para login
+              </Link>
+            </div>
+          </CardFooter>
+        </Card>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Supabase auth callback handler
- add reset password form page
- clarify email instructions in forgot password flow
- document reset password steps in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68479f452e80832da821df6aa4fdde7c