### PR TITLE
Hide pending pets from public view

### DIFF
--- a/app/adocao/AdocaoClientPage.tsx
+++ b/app/adocao/AdocaoClientPage.tsx
@@ -34,7 +34,10 @@ export default function AdocaoClientPage({
     const fetchPets = async () => {
       setLoading(true)
       try {
-        let query = supabase.from("pets").select("*", { count: "exact" })
+        let query = supabase
+          .from("pets")
+          .select("*", { count: "exact" })
+          .eq("status", "approved")
 
         // Aplicar filtros
         if (filters.species) {

--- a/app/encontrados/EncontradosClientPage.tsx
+++ b/app/encontrados/EncontradosClientPage.tsx
@@ -45,7 +45,10 @@ export default function EncontradosClientPage({
     const fetchPets = async () => {
       setLoading(true)
       try {
-        let query = supabase.from("pets_found").select("*", { count: "exact" })
+        let query = supabase
+          .from("pets_found")
+          .select("*", { count: "exact" })
+          .eq("status", "approved")
 
         // Aplicar filtros
         if (filters.species && filters.species !== "all") {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -67,7 +67,8 @@ export async function getPetsForAdoption(page = 1, pageSize = 12, filters = {}):
       .from("pets")
       .select(`*, ongs(id, name, logo_url, city)`, { count: "exact" })
       .eq("category", "adoption") // Filter for adoption pets
-      .in("status", ["approved", "pending"]) // Include both approved and pending
+      // Mostrar apenas pets aprovados
+      .eq("status", "approved")
       .order("created_at", { ascending: false })
       .range(from, to)
 
@@ -177,7 +178,8 @@ export async function getLostPets(page = 1, pageSize = 12, filters = {}): Promis
       .from("pets")
       .select("*", { count: "exact" })
       .eq("category", "lost") // Filtrar apenas pets perdidos
-      .in("status", ["approved", "pending"]) // Include both approved and pending
+      // Mostrar apenas pets aprovados
+      .eq("status", "approved")
       .order("created_at", { ascending: false })
       .range(from, to)
 
@@ -286,7 +288,8 @@ export async function getFoundPets(page = 1, pageSize = 12, filters = {}): Promi
       .from("pets")
       .select("*", { count: "exact" })
       .eq("category", "found") // Filtrar apenas pets encontrados
-      .in("status", ["approved", "pending"]) // Include both approved and pending
+      // Mostrar apenas pets aprovados
+      .eq("status", "approved")
       .order("created_at", { ascending: false })
       .range(from, to)
 
@@ -377,8 +380,8 @@ export async function getEvents(page = 1, pageSize = 12, filters: any = {}) {
     // Substituir a query por:
     let query = supabase.from("events").select("*, ongs(id, name, logo_url, city)", { count: "exact" })
 
-    // Mostrar apenas eventos aprovados ou sem status (legados)
-    query = query.in("status", ["approved", "pending"]) // Include both approved and pending
+    // Mostrar apenas eventos aprovados
+    query = query.eq("status", "approved")
 
     // Aplicar filtros se existirem
     if (filters.title) {


### PR DESCRIPTION
## Summary
- show only approved pets in supabase queries
- filter adoption and found pets on client side by approved status

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6847a9979d48832db6276a417fe96f34