### PR TITLE
Support main_image_url for pets

### DIFF
--- a/app/admin-alt/pets/pet-detail.tsx
+++ b/app/admin-alt/pets/pet-detail.tsx
@@ -165,7 +165,7 @@ export function PetDetail({ petId, petType }: PetDetailProps) {
             <CardContent className="p-0">
               <div className="relative aspect-square w-full">
                 <Image
-                  src={pet.image_url || "/placeholder.svg?height=400&width=400&query=pet"}
+                  src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=400&width=400&query=pet"}
                   alt={pet.name || "Pet"}
                   fill
                   className="object-cover rounded-t-lg"

--- a/app/admin/ongs/[id]/page.tsx
+++ b/app/admin/ongs/[id]/page.tsx
@@ -243,7 +243,7 @@ export default async function AdminOngDetailsPage({ params }: { params: { id: st
                         <Card key={pet.id} className="overflow-hidden">
                           <div className="relative aspect-square">
                             <Image
-                              src={pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
+                              src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
                               alt={pet.name}
                               fill
                               className="object-cover"

--- a/app/admin/pets/pets-table.tsx
+++ b/app/admin/pets/pets-table.tsx
@@ -323,7 +323,7 @@ export function PetsTable({ pets, type }: PetTableProps) {
                     {pet.image_url ? (
                       <div className="relative h-12 w-12 rounded-md overflow-hidden">
                         <Image
-                          src={pet.image_url || "/placeholder.svg"}
+                          src={pet.main_image_url || pet.image_url || "/placeholder.svg"}
                           alt={pet.name || "Pet"}
                           fill
                           className="object-cover"

--- a/app/adocao/AdocaoClientPage.tsx
+++ b/app/adocao/AdocaoClientPage.tsx
@@ -123,7 +123,7 @@ export default function AdocaoClientPage({
                   key={pet.id}
                   id={pet.id}
                   name={pet.name || "Pet sem nome"}
-                  image={pet.image_url}
+                  image={pet.main_image_url || pet.image_url}
                   species={pet.species}
                   species_other={pet.species_other}
                   breed={pet.breed}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -221,7 +221,7 @@ function DashboardContent() {
                     >
                       <div className="relative h-12 w-12 rounded-md overflow-hidden">
                         <Image
-                          src={pet.image_url || "/placeholder.svg?height=48&width=48&query=pet"}
+                          src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=48&width=48&query=pet"}
                           alt={pet.name || "Pet"}
                           fill
                           className="object-cover"

--- a/app/dashboard/pets/[type]/[id]/delete/page.tsx
+++ b/app/dashboard/pets/[type]/[id]/delete/page.tsx
@@ -211,7 +211,7 @@ function DeletePetContent({ params }: { params: { type: string; id: string } }) 
           <CardContent className="flex flex-col items-center">
             <div className="relative w-[200px] h-[200px] rounded-lg overflow-hidden mb-4">
               <Image
-                src={pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
+                src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
                 alt={pet.name || "Pet"}
                 fill
                 className="object-cover"

--- a/app/dashboard/pets/[type]/[id]/page.tsx
+++ b/app/dashboard/pets/[type]/[id]/page.tsx
@@ -276,7 +276,7 @@ function PetDetails({ type, id }: { type: string; id: string }) {
             <CardContent className="p-0">
               <div className="relative aspect-square w-full">
                 <Image
-                  src={pet.image_url || "/placeholder.svg?height=400&width=400&query=pet"}
+                  src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=400&width=400&query=pet"}
                   alt={pet.name || "Pet"}
                   fill
                   className="object-cover rounded-t-lg"

--- a/app/dashboard/pets/adoption/[id]/delete/page.tsx
+++ b/app/dashboard/pets/adoption/[id]/delete/page.tsx
@@ -145,7 +145,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           <CardContent className="flex flex-col items-center">
             <div className="relative w-[200px] h-[200px] rounded-lg overflow-hidden mb-4">
               <Image
-                src={pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
+                src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
                 alt={pet.name || "Pet"}
                 fill
                 className="object-cover"

--- a/app/dashboard/pets/found/[id]/delete/page.tsx
+++ b/app/dashboard/pets/found/[id]/delete/page.tsx
@@ -145,7 +145,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           <CardContent className="flex flex-col items-center">
             <div className="relative w-[200px] h-[200px] rounded-lg overflow-hidden mb-4">
               <Image
-                src={pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
+                src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
                 alt={pet.name || "Pet"}
                 fill
                 className="object-cover"

--- a/app/dashboard/pets/lost/[id]/delete/page.tsx
+++ b/app/dashboard/pets/lost/[id]/delete/page.tsx
@@ -145,7 +145,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           <CardContent className="flex flex-col items-center">
             <div className="relative w-[200px] h-[200px] rounded-lg overflow-hidden mb-4">
               <Image
-                src={pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
+                src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=200&width=200&query=pet"}
                 alt={pet.name || "Pet"}
                 fill
                 className="object-cover"

--- a/app/dashboard/pets/lost/[id]/page.tsx
+++ b/app/dashboard/pets/lost/[id]/page.tsx
@@ -164,7 +164,7 @@ function LostPetDetails({ id }: { id: string }) {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="relative aspect-square overflow-hidden rounded-lg">
               <Image
-                src={pet.image_url || "/placeholder.svg?height=400&width=400&query=pet"}
+                src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=400&width=400&query=pet"}
                 alt={pet.name || "Pet"}
                 fill
                 className="object-cover"

--- a/app/dashboard/pets/page.tsx
+++ b/app/dashboard/pets/page.tsx
@@ -334,7 +334,7 @@ function PetsContent() {
           <Card key={`adoption-${pet.id}`} className="overflow-hidden">
             <div className="relative aspect-video">
               <Image
-                src={pet.image_url || "/placeholder.svg?height=300&width=400&query=cute+pet"}
+                src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=300&width=400&query=cute+pet"}
                 alt={pet.name || "Pet para adoção"}
                 fill
                 className="object-cover"
@@ -392,7 +392,7 @@ function PetsContent() {
           <Card key={`lost-${pet.id}`} className="overflow-hidden">
             <div className="relative aspect-video">
               <Image
-                src={pet.image_url || "/placeholder.svg?height=300&width=400&query=lost+pet"}
+                src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=300&width=400&query=lost+pet"}
                 alt={pet.name || "Pet perdido"}
                 fill
                 className="object-cover"
@@ -450,7 +450,7 @@ function PetsContent() {
           <Card key={`found-${pet.id}`} className="overflow-hidden">
             <div className="relative aspect-video">
               <Image
-                src={pet.image_url || "/placeholder.svg?height=300&width=400&query=found+pet"}
+                src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=300&width=400&query=found+pet"}
                 alt={pet.name || "Pet encontrado"}
                 fill
                 className="object-cover"
@@ -562,7 +562,7 @@ function PetsContent() {
                 <Card key={`adoption-${pet.id}`} className="overflow-hidden">
                   <div className="relative aspect-video">
                     <Image
-                      src={pet.image_url || "/placeholder.svg?height=300&width=400&query=cute+pet"}
+                      src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=300&width=400&query=cute+pet"}
                       alt={pet.name || "Pet para adoção"}
                       fill
                       className="object-cover"
@@ -620,7 +620,7 @@ function PetsContent() {
                 <Card key={`lost-${pet.id}`} className="overflow-hidden">
                   <div className="relative aspect-video">
                     <Image
-                      src={pet.image_url || "/placeholder.svg?height=300&width=400&query=lost+pet"}
+                      src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=300&width=400&query=lost+pet"}
                       alt={pet.name || "Pet perdido"}
                       fill
                       className="object-cover"
@@ -678,7 +678,7 @@ function PetsContent() {
                 <Card key={`found-${pet.id}`} className="overflow-hidden">
                   <div className="relative aspect-video">
                     <Image
-                      src={pet.image_url || "/placeholder.svg?height=300&width=400&query=found+pet"}
+                      src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=300&width=400&query=found+pet"}
                       alt={pet.name || "Pet encontrado"}
                       fill
                       className="object-cover"
@@ -733,7 +733,7 @@ function PetsContent() {
                 <Card key={`resolved-${pet.id}`} className="overflow-hidden">
                   <div className="relative aspect-video">
                     <Image
-                      src={pet.image_url || "/placeholder.svg?height=300&width=400&query=resolved+pet"}
+                      src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=300&width=400&query=resolved+pet"}
                       alt={pet.name || "Pet resolvido"}
                       fill
                       className="object-cover"

--- a/app/encontrados/EncontradosClientPage.tsx
+++ b/app/encontrados/EncontradosClientPage.tsx
@@ -165,7 +165,7 @@ export default function EncontradosClientPage({
                   key={pet.id}
                   id={pet.id}
                   name={pet.name || "Pet sem nome"}
-                  image={pet.image_url}
+                  image={pet.main_image_url || pet.image_url}
                   species={pet.species}
                   species_other={pet.species_other}
                   breed={pet.breed}

--- a/app/my-pets/page.tsx
+++ b/app/my-pets/page.tsx
@@ -68,7 +68,7 @@ export default async function MyPetsPage() {
                   key={pet.id}
                   id={pet.id}
                   name={pet.name}
-                  image={pet.image_url}
+                  image={pet.main_image_url || pet.image_url}
                   species={pet.species}
                   age={pet.age}
                   size={pet.size}
@@ -101,7 +101,7 @@ export default async function MyPetsPage() {
                   key={pet.id}
                   id={pet.id}
                   name={pet.name || "Pet sem nome"}
-                  image={pet.image_url}
+                  image={pet.main_image_url || pet.image_url}
                   species={pet.species}
                   size={pet.size}
                   gender={pet.gender}
@@ -133,7 +133,7 @@ export default async function MyPetsPage() {
                   key={pet.id}
                   id={pet.id}
                   name={pet.name || "Pet sem nome"}
-                  image={pet.image_url}
+                  image={pet.main_image_url || pet.image_url}
                   species={pet.species}
                   size={pet.size}
                   gender={pet.gender}
@@ -165,7 +165,7 @@ export default async function MyPetsPage() {
                   key={pet.id}
                   id={pet.id}
                   name={pet.name || "Pet sem nome"}
-                  image={pet.image_url}
+                  image={pet.main_image_url || pet.image_url}
                   species={pet.species}
                   size={pet.size}
                   gender={pet.gender}

--- a/app/ongs/[slug]/page.tsx
+++ b/app/ongs/[slug]/page.tsx
@@ -161,7 +161,7 @@ export default async function OngPage({ params }: { params: { slug: string } }) 
                       key={pet.id}
                       id={pet.id}
                       name={pet.name}
-                      image={pet.image_url}
+                      image={pet.main_image_url || pet.image_url}
                       location={`${ong.city}, ${ong.state}`}
                       species={pet.species}
                       age={pet.age}

--- a/app/ongs/dashboard/page.tsx
+++ b/app/ongs/dashboard/page.tsx
@@ -196,7 +196,7 @@ export default function OngDashboardPage() {
                       <div key={pet.id} className="flex items-center gap-4 p-3 rounded-md border">
                         <div className="relative h-16 w-16 rounded-md overflow-hidden">
                           <Image
-                            src={pet.image_url || "/placeholder.svg?height=64&width=64&query=pet"}
+                            src={pet.main_image_url || pet.image_url || "/placeholder.svg?height=64&width=64&query=pet"}
                             alt={pet.name}
                             fill
                             className="object-cover"

--- a/app/ongs/dashboard/pets/[id]/edit/page.tsx
+++ b/app/ongs/dashboard/pets/[id]/edit/page.tsx
@@ -132,10 +132,10 @@ export default function EditPetPage({ params }: { params: { id: string } }) {
           is_vaccinated: pet.is_vaccinated || false,
           is_special_needs: pet.is_special_needs || false,
           special_needs_description: pet.special_needs_description || "",
-          image_url: pet.image_url,
+          image_url: pet.main_image_url || pet.image_url,
         })
 
-        setImageUrl(pet.image_url)
+        setImageUrl(pet.main_image_url || pet.image_url)
       } catch (err: any) {
         console.error("Erro ao carregar pet:", err)
         setError(err.message || "Ocorreu um erro ao carregar o pet")

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,7 +60,7 @@ export default async function Home() {
                   <PetCard
                     id={pet.id}
                     name={pet.name}
-                    image={pet.image_url || "/a-cute-pet.png"}
+                    image={pet.main_image_url || pet.image_url || "/a-cute-pet.png"}
                     species={pet.species}
                     species_other={pet.species_other}
                     age={pet.age}
@@ -104,7 +104,7 @@ export default async function Home() {
                   <PetCard
                     id={pet.id}
                     name={pet.name}
-                    image={pet.image_url || "/a-cute-pet.png"}
+                    image={pet.main_image_url || pet.image_url || "/a-cute-pet.png"}
                     species={pet.species}
                     species_other={pet.species_other}
                     age={pet.age}

--- a/app/perdidos/[slug]/page.tsx
+++ b/app/perdidos/[slug]/page.tsx
@@ -67,7 +67,7 @@ export async function generateMetadata({ params }: PetLostDetailPageProps): Prom
           : `${pet.name} - ${speciesDisplay} perdido ${location ? `em ${location}` : ""}. Ajude a encontrá-lo.`,
         images: [
           {
-            url: pet.image_url || "/placeholder.svg?key=p34o7",
+            url: pet.main_image_url || pet.image_url || "/placeholder.svg?key=p34o7",
             width: 1200,
             height: 630,
             alt: pet.name || "Pet perdido",

--- a/components/pet-details.tsx
+++ b/components/pet-details.tsx
@@ -32,6 +32,7 @@ export default function PetDetails({ pet, type }: PetDetailsProps) {
 
   // Preparar as imagens
   const images = []
+  if (pet.main_image_url) images.push(pet.main_image_url)
   if (pet.image_url) images.push(pet.image_url)
   if (pet.additional_images && Array.isArray(pet.additional_images)) {
     images.push(...pet.additional_images)

--- a/lib/structured-data.ts
+++ b/lib/structured-data.ts
@@ -10,7 +10,8 @@ export function generateAdoptionPetSchema(pet: any, options: { baseUrl?: string 
 
     const baseUrl = options.baseUrl || "https://www.petadot.com.br"
     const petUrl = `${baseUrl}/adocao/${pet.slug || pet.id}`
-    const imageUrl = pet.image_url || `${baseUrl}/placeholder.svg?height=600&width=800&query=pet`
+    const defaultPlaceholder = `${baseUrl}/placeholder.svg?height=600&width=800&query=pet`
+    const imageUrl = pet.main_image_url || pet.image_url || defaultPlaceholder
 
     // Obter informações da ONG, se disponível
     const ong = pet.ongs || {}
@@ -86,7 +87,8 @@ export function generateLostPetSchema(pet: any, options: { baseUrl?: string } = 
 
     const baseUrl = options.baseUrl || "https://www.petadot.com.br"
     const petUrl = `${baseUrl}/perdidos/${pet.slug || pet.id}`
-    const imageUrl = pet.image_url || `${baseUrl}/placeholder.svg?height=600&width=800&query=pet+perdido`
+    const defaultPlaceholder = `${baseUrl}/placeholder.svg?height=600&width=800&query=pet+perdido`
+    const imageUrl = pet.main_image_url || pet.image_url || defaultPlaceholder
 
     // Preparar a localização
     const location = pet.location || (pet.city && pet.state ? `${pet.city}, ${pet.state}` : "")
@@ -135,7 +137,8 @@ export function generateFoundPetSchema(pet: any, options: { baseUrl?: string } =
 
     const baseUrl = options.baseUrl || "https://www.petadot.com.br"
     const petUrl = `${baseUrl}/encontrados/${pet.slug || pet.id}`
-    const imageUrl = pet.image_url || `${baseUrl}/placeholder.svg?height=600&width=800&query=pet+encontrado`
+    const defaultPlaceholder = `${baseUrl}/placeholder.svg?height=600&width=800&query=pet+encontrado`
+    const imageUrl = pet.main_image_url || pet.image_url || defaultPlaceholder
 
     // Preparar a localização
     const location = pet.location || (pet.city && pet.state ? `${pet.city}, ${pet.state}` : "")


### PR DESCRIPTION
## Summary
- prioritize `main_image_url` when showing pets
- update pet details gallery
- include new field in structured data helpers
- adjust admin and dashboard pages

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6847b0441550832daf23208f29d0cbbf