### PR TITLE
Fix ModerationActions event page usage

### DIFF
--- a/app/admin-alt/events/[id]/page.tsx
+++ b/app/admin-alt/events/[id]/page.tsx
@@ -125,7 +125,7 @@ export default async function EventDetailPage({ params }: { params: { id: string
                 </div>
                 <div>
                   <h3 className="font-medium mb-2">Ações de Moderação</h3>
-                  <ModerationActions id={event.id} status={event.status} type="event" />
+                  <ModerationActions id={event.id} type="event" />
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- remove `status` prop from `<ModerationActions>` usage in admin event page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684824fd4e10832d81f321ab6700ea28