### PR TITLE
Switch events to use `date` field

### DIFF
--- a/app/admin-alt/events/[id]/delete/delete-event-form.tsx
+++ b/app/admin-alt/events/[id]/delete/delete-event-form.tsx
@@ -100,7 +100,7 @@ export function AdminDeleteEventForm({ event }: { event: any }) {
               <h2 className="text-xl font-bold">{event.title}</h2>
               <div className="flex items-center justify-center gap-1 text-muted-foreground mt-2">
                 <CalendarIcon className="h-4 w-4" />
-                <span>{formatDate(event.start_date)}</span>
+                <span>{formatDate(event.date)}</span>
               </div>
               <div className="flex items-center justify-center gap-1 text-muted-foreground">
                 <MapPinIcon className="h-4 w-4" />

--- a/app/admin-alt/events/page.tsx
+++ b/app/admin-alt/events/page.tsx
@@ -51,7 +51,7 @@ export default async function AdminEventsPage() {
     .from("events")
     .select("*, users!events_user_id_fkey(name)")
     .eq("status", "approved")
-    .order("start_date", { ascending: true })
+    .order("date", { ascending: true })
 
   const { data: rejectedEvents, error: rejectedEventsError } = await supabase
     .from("events")

--- a/app/eventos/[slug]/page.tsx
+++ b/app/eventos/[slug]/page.tsx
@@ -50,7 +50,7 @@ export default async function EventDetailsPage({ params }: EventDetailsPageProps
   }
 
   // Formatar datas
-  const eventDate = new Date(event.start_date)
+  const eventDate = new Date(event.date)
   const formattedDate = eventDate.toLocaleDateString("pt-BR", {
     day: "2-digit",
     month: "2-digit",
@@ -66,7 +66,7 @@ export default async function EventDetailsPage({ params }: EventDetailsPageProps
   const isPastEvent = eventDate < new Date()
 
   // Verificar se o evento tem data de término
-  const hasEndDate = event.end_date && event.end_date !== event.start_date
+  const hasEndDate = event.end_date && event.end_date !== event.date
 
   // Formatar data de término, se existir
   const endDate = hasEndDate ? new Date(event.end_date!) : null

--- a/app/events/analytics/page.tsx
+++ b/app/events/analytics/page.tsx
@@ -42,9 +42,9 @@ export default function EventAnalyticsPage() {
       const now = new Date()
 
       // Calculate statistics
-      const upcomingEvents = events.filter((event) => new Date(event.start_date) > now).length
+      const upcomingEvents = events.filter((event) => new Date(event.date) > now).length
 
-      const pastEvents = events.filter((event) => new Date(event.start_date) <= now).length
+      const pastEvents = events.filter((event) => new Date(event.date) <= now).length
 
       // Group by city
       const cityGroups = events.reduce(
@@ -242,7 +242,7 @@ export default function EventAnalyticsPage() {
                           {event.city}, {event.state}
                         </p>
                       </div>
-                      <Badge variant="outline">{formatDate(event.start_date)}</Badge>
+                      <Badge variant="outline">{formatDate(event.date)}</Badge>
                     </div>
                     <p className="text-sm text-muted-foreground line-clamp-2">{event.description}</p>
                   </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,7 +38,9 @@ export default async function Home() {
     const recentAdoptionPets = adoptionPets
     const recentLostPets = lostPets
     // Filtramos apenas eventos futuros
-    const upcomingEvents = events.filter((event) => new Date(event.start_date) >= new Date()).slice(0, 3)
+    const upcomingEvents = events
+      .filter((event) => new Date(event.date) >= new Date())
+      .slice(0, 3)
 
     return (
       <div className="flex flex-col min-h-screen">
@@ -158,7 +160,7 @@ export default async function Home() {
                     <div className="p-4">
                       <h3 className="font-bold text-lg">{event.title}</h3>
                       <p className="text-sm text-gray-600">
-                        Data: {new Date(event.start_date).toLocaleDateString("pt-BR")}
+                        Data: {new Date(event.date).toLocaleDateString("pt-BR")}
                       </p>
                       <p className="text-sm text-gray-600">Local: {event.location}</p>
                       <p className="mt-2 text-sm line-clamp-2">{event.description}</p>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -397,14 +397,18 @@ export async function getEvents(page = 1, pageSize = 12, filters: any = {}) {
     }
 
     if (filters.date) {
-      query = query.gte("start_date", filters.date)
+      // Filtrar por data de realização do evento
+      query = query.gte("date", filters.date)
     }
 
     // Aplicar paginação
     const from = (page - 1) * pageSize
     const to = from + pageSize - 1
 
-    const { data, error, count } = await query.order("start_date", { ascending: true }).range(from, to)
+    const { data, error, count } = await query
+      // Ordenar eventos pela data de realização
+      .order("date", { ascending: true })
+      .range(from, to)
 
     if (error) {
       console.error("Erro ao buscar eventos:", error)


### PR DESCRIPTION
## Summary
- fetch events using `date` instead of `start_date`
- reference `event.date` everywhere in the app

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684880b9417c832d810ae62f3cb4d9ba