### PR TITLE
Fix event query column

### DIFF
--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -40,11 +40,11 @@ export async function getSystemStats() {
       .select("*", { count: "exact", head: true })
       .eq("status", "aprovado")
 
-    // Contar eventos
+    // Contar eventos (coluna "date")
     const { count: eventsCount, error: eventsError } = await supabase
       .from("events")
       .select("*", { count: "exact", head: true })
-      .gte("event_date", new Date().toISOString())
+      .gte("date", new Date().toISOString())
 
     // Contar usuários
     const { count: usersCount, error: usersError } = await supabase


### PR DESCRIPTION
## Summary
- update `lib/stats.ts` to query upcoming events using the `date` column

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684885fd5cc8832dafb55e9401816595