### PR TITLE
Filter upcoming events on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,9 @@ export default async function Home() {
     // Buscar apenas os primeiros 4 pets para cada categoria (sem paginação completa)
     const adoptionPetsResult = await getPetsForAdoption(1, 4)
     const lostPetsResult = await getLostPets(1, 4)
-    const eventsResult = await getEvents(1, 4)
+    const eventsResult = await getEvents(1, 4, {
+      date: new Date().toISOString(),
+    })
 
     // Extrair os arrays de dados dos resultados paginados
     const adoptionPets = adoptionPetsResult.data || []


### PR DESCRIPTION
## Summary
- filter future events when retrieving events for the landing page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68488c958e80832db2d21313d90c6dfb