### PR TITLE
Add events table schema and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,13 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Database Setup
+
+When setting up a new Supabase project, run the SQL files inside the `db` folder. The events table can be created with:
+
+```bash
+supabase db execute ./db/create-events-table.sql
+```
+
+Ensure the Supabase CLI is linked to your project before running the command.

--- a/db/create-events-table.sql
+++ b/db/create-events-table.sql
@@ -1,0 +1,25 @@
+-- Create events table if it doesn't exist
+CREATE TABLE IF NOT EXISTS events (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name VARCHAR(255) NOT NULL,
+  description TEXT,
+  slug TEXT UNIQUE,
+  date TIMESTAMPTZ NOT NULL,
+  end_date TIMESTAMPTZ,
+  location TEXT NOT NULL,
+  address TEXT,
+  city VARCHAR(100),
+  state VARCHAR(100),
+  postal_code VARCHAR(20),
+  image_url TEXT,
+  ong_id UUID REFERENCES ongs(id),
+  user_id UUID REFERENCES users(id),
+  status VARCHAR(50) DEFAULT 'pending',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for faster lookups
+CREATE INDEX IF NOT EXISTS idx_events_ong_id ON events(ong_id);
+CREATE INDEX IF NOT EXISTS idx_events_user_id ON events(user_id);
+CREATE INDEX IF NOT EXISTS idx_events_slug ON events(slug);


### PR DESCRIPTION
## Summary
- add SQL migration for the `events` table
- document how to run migrations in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848e624eeec832da32c7e3d38a7dfec