### PR TITLE
Replace old event fields

### DIFF
--- a/app/admin-alt/events/[id]/delete/delete-event-form.tsx
+++ b/app/admin-alt/events/[id]/delete/delete-event-form.tsx
@@ -97,10 +97,10 @@ export function AdminDeleteEventForm({ event }: { event: any }) {
           </CardHeader>
           <CardContent>
             <div className="text-center mb-6">
-              <h2 className="text-xl font-bold">{event.title}</h2>
+              <h2 className="text-xl font-bold">{event.name}</h2>
               <div className="flex items-center justify-center gap-1 text-muted-foreground mt-2">
                 <CalendarIcon className="h-4 w-4" />
-                <span>{formatDate(event.date)}</span>
+                <span>{formatDate(event.start_date)}</span>
               </div>
               <div className="flex items-center justify-center gap-1 text-muted-foreground">
                 <MapPinIcon className="h-4 w-4" />

--- a/app/admin-alt/moderation/page.tsx
+++ b/app/admin-alt/moderation/page.tsx
@@ -418,7 +418,7 @@ export default function AdminModerationPage() {
                         <div className="w-full md:w-1/4 aspect-square relative rounded-md overflow-hidden">
                           <Image
                             src={getImageSrc(event.image_url) || "/placeholder.svg"}
-                            alt={event.title || "Evento rejeitado"}
+                            alt={event.name || "Evento rejeitado"}
                             fill
                             className="object-cover"
                             unoptimized={getImageSrc(event.image_url).includes("placeholder.svg")}
@@ -427,7 +427,7 @@ export default function AdminModerationPage() {
                         <div className="flex-1">
                           <div className="flex justify-between items-start">
                             <div>
-                              <h3 className="font-semibold text-lg">{event.title || "Evento sem título"}</h3>
+                              <h3 className="font-semibold text-lg">{event.name || "Evento sem título"}</h3>
                               <Badge variant="destructive" className="mt-1">
                                 Rejeitado
                               </Badge>

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -75,7 +75,7 @@ export default function AdminDashboard() {
         ...(pendingEvents || []).map((event) => ({
           id: event.id,
           type: "event" as const,
-          title: event.title || "Evento sem título",
+          title: event.name || "Evento sem título",
           description: event.description || "Sem descrição",
           created_at: event.created_at,
           status: event.status,

--- a/app/admin/ongs/[id]/page.tsx
+++ b/app/admin/ongs/[id]/page.tsx
@@ -309,7 +309,7 @@ export default async function AdminOngDetailsPage({ params }: { params: { id: st
                           <CardContent className="p-3">
                             <h3 className="font-medium">{event.name}</h3>
                             <p className="text-xs text-muted-foreground">
-                              {new Date(event.date).toLocaleDateString("pt-BR")}
+                              {new Date(event.start_date).toLocaleDateString("pt-BR")}
                             </p>
                             <div className="flex justify-end mt-2">
                               <Button variant="ghost" size="sm" asChild>

--- a/app/admin/utils/populate-slugs.tsx
+++ b/app/admin/utils/populate-slugs.tsx
@@ -193,7 +193,7 @@ export default function PopulateSlugsUtility() {
       // Update each event with a slug
       for (const event of events || []) {
         try {
-          const slug = await generateEventSlug(event.title || "evento", event.city, event.state, event.id)
+          const slug = await generateEventSlug(event.name || "evento", event.city, event.state, event.id)
 
           const { error: updateError } = await supabase.from("events").update({ slug }).eq("id", event.id)
 

--- a/app/events/analytics/page.tsx
+++ b/app/events/analytics/page.tsx
@@ -42,9 +42,9 @@ export default function EventAnalyticsPage() {
       const now = new Date()
 
       // Calculate statistics
-      const upcomingEvents = events.filter((event) => new Date(event.date) > now).length
+      const upcomingEvents = events.filter((event) => new Date(event.start_date) > now).length
 
-      const pastEvents = events.filter((event) => new Date(event.date) <= now).length
+      const pastEvents = events.filter((event) => new Date(event.start_date) <= now).length
 
       // Group by city
       const cityGroups = events.reduce(
@@ -237,12 +237,12 @@ export default function EventAnalyticsPage() {
                   <div key={event.id} className="border rounded-lg p-4">
                     <div className="flex justify-between items-start mb-2">
                       <div>
-                        <h4 className="font-semibold">{event.title}</h4>
+                        <h4 className="font-semibold">{event.name}</h4>
                         <p className="text-sm text-muted-foreground">
                           {event.city}, {event.state}
                         </p>
                       </div>
-                      <Badge variant="outline">{formatDate(event.date)}</Badge>
+                      <Badge variant="outline">{formatDate(event.start_date)}</Badge>
                     </div>
                     <p className="text-sm text-muted-foreground line-clamp-2">{event.description}</p>
                   </div>

--- a/app/ongs/[slug]/page.tsx
+++ b/app/ongs/[slug]/page.tsx
@@ -190,7 +190,7 @@ export default async function OngPage({ params }: { params: { slug: string } }) 
                       id={event.id}
                       name={event.name}
                       image={event.image_url}
-                      date={event.date}
+                      start_date={event.start_date}
                       location={event.location}
                       description={event.description}
                     />

--- a/app/ongs/dashboard/eventos/[id]/edit/page.tsx
+++ b/app/ongs/dashboard/eventos/[id]/edit/page.tsx
@@ -47,7 +47,7 @@ export default function EditEventPage() {
         }
 
         // Formatar a data para o formato YYYY-MM-DD
-        const eventDate = result.event.date ? new Date(result.event.date) : new Date()
+        const eventDate = result.event.start_date ? new Date(result.event.start_date) : new Date()
         const formattedDate = eventDate.toISOString().split("T")[0]
 
         setFormData({

--- a/app/ongs/dashboard/page.tsx
+++ b/app/ongs/dashboard/page.tsx
@@ -66,7 +66,7 @@ export default function OngDashboardPage() {
           .from("events")
           .select("*")
           .eq("ong_id", ongData.id)
-          .order("date", { ascending: true }) // Alterado de event_date para date
+          .order("start_date", { ascending: true })
 
         if (eventsError) {
           console.error("Erro ao buscar eventos:", eventsError)
@@ -263,14 +263,14 @@ export default function OngDashboardPage() {
                         <div className="relative h-16 w-16 rounded-md overflow-hidden">
                           <Image
                             src={event.image_url || "/placeholder.svg?height=64&width=64&query=event"}
-                            alt={event.title || event.name}
+                            alt={event.name}
                             fill
                             className="object-cover"
                           />
                         </div>
                         <div className="flex-grow">
-                          <h3 className="font-medium">{event.title || event.name}</h3>
-                          <p className="text-sm text-muted-foreground">{formatEventDate(event.date)}</p>
+                          <h3 className="font-medium">{event.name}</h3>
+                          <p className="text-sm text-muted-foreground">{formatEventDate(event.start_date)}</p>
                           <div className="text-xs mt-1 inline-block px-2 py-0.5 rounded-full bg-gray-100">
                             Status:{" "}
                             {event.status === "approved"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,7 +41,7 @@ export default async function Home() {
     const recentLostPets = lostPets
     // Filtramos apenas eventos futuros
     const upcomingEvents = events
-      .filter((event) => new Date(event.date) >= new Date())
+      .filter((event) => new Date(event.start_date) >= new Date())
       .slice(0, 3)
 
     return (
@@ -152,7 +152,7 @@ export default async function Home() {
                     <div className="h-48 relative">
                       <OptimizedImage
                         src={event.image_url || "/placeholder.svg?height=192&width=384&query=pet+event"}
-                        alt={event.title}
+                        alt={event.name}
                         width={384}
                         height={192}
                         className="w-full h-full"
@@ -160,9 +160,9 @@ export default async function Home() {
                       />
                     </div>
                     <div className="p-4">
-                      <h3 className="font-bold text-lg">{event.title}</h3>
+                      <h3 className="font-bold text-lg">{event.name}</h3>
                       <p className="text-sm text-gray-600">
-                        Data: {new Date(event.date).toLocaleDateString("pt-BR")}
+                        Data: {new Date(event.start_date).toLocaleDateString("pt-BR")}
                       </p>
                       <p className="text-sm text-gray-600">Local: {event.location}</p>
                       <p className="mt-2 text-sm line-clamp-2">{event.description}</p>

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -44,7 +44,7 @@ export async function getSystemStats() {
     const { count: eventsCount, error: eventsError } = await supabase
       .from("events")
       .select("*", { count: "exact", head: true })
-      .gte("event_date", new Date().toISOString())
+      .gte("start_date", new Date().toISOString())
 
     // Contar usuários
     const { count: usersCount, error: usersError } = await supabase


### PR DESCRIPTION
## Summary
- rename `event.date` to `event.start_date`
- rename `event.title` to `event.name`
- adjust filtering and queries to use the new fields

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849bf3ffbd8832da8b9d3a268c682c3