### PR TITLE
Use name and start_date in event filters

### DIFF
--- a/app/api/eventos/route.ts
+++ b/app/api/eventos/route.ts
@@ -6,16 +6,16 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url)
     const page = Number(searchParams.get("page") || "1")
     const pageSize = Number(searchParams.get("pageSize") || "12")
-    const title = searchParams.get("title") || undefined
+    const name = searchParams.get("name") || undefined
     const city = searchParams.get("city") || undefined
     const state = searchParams.get("state") || undefined
-    const date = searchParams.get("date") || undefined
+    const start_date = searchParams.get("start_date") || undefined
 
     const filters: any = {}
-    if (title) filters.title = title
+    if (name) filters.name = name
     if (city) filters.city = city
     if (state) filters.state = state
-    if (date) filters.date = date
+    if (start_date) filters.start_date = start_date
 
     const { data: events, count } = await getEvents(page, pageSize, filters)
 

--- a/app/eventos/EventosClientPage.tsx
+++ b/app/eventos/EventosClientPage.tsx
@@ -32,10 +32,10 @@ interface EventosClientPageProps {
   currentPage: number
   pageSize: number
   initialFilters: {
-    title?: string
+    name?: string
     city?: string
     state?: string
-    date?: string
+    start_date?: string
   }
 }
 
@@ -47,8 +47,8 @@ export function EventosClientPage({
   initialFilters,
 }: EventosClientPageProps) {
   const [eventos, setEventos] = useState<Evento[]>(initialEvents)
-  const [search, setSearch] = useState(initialFilters.title || "")
-  const [date, setDate] = useState<Date | undefined>(initialFilters.date ? new Date(initialFilters.date) : undefined)
+  const [search, setSearch] = useState(initialFilters.name || "")
+  const [date, setDate] = useState<Date | undefined>(initialFilters.start_date ? new Date(initialFilters.start_date) : undefined)
   const router = useRouter()
   const searchParams = useSearchParams()
   const { toast } = useToast()
@@ -57,8 +57,8 @@ export function EventosClientPage({
   useEffect(() => {
     const fetchEventos = async () => {
       const params = new URLSearchParams()
-      if (search) params.set("title", search)
-      if (date) params.set("date", format(date, "yyyy-MM-dd"))
+      if (search) params.set("name", search)
+      if (date) params.set("start_date", format(date, "yyyy-MM-dd"))
       params.set("page", currentPage.toString())
       params.set("pageSize", pageSize.toString())
 
@@ -82,9 +82,9 @@ export function EventosClientPage({
     // Só busca se os filtros mudarem ou se for a primeira renderização e initialEvents estiver vazio
     // A busca inicial é feita pelo Server Component
     if (
-      search !== (initialFilters.title || "") ||
-      (date && format(date, "yyyy-MM-dd") !== (initialFilters.date || "")) ||
-      (!date && initialFilters.date) // if date was set initially but now cleared
+      search !== (initialFilters.name || "") ||
+      (date && format(date, "yyyy-MM-dd") !== (initialFilters.start_date || "")) ||
+      (!date && initialFilters.start_date) // if date was set initially but now cleared
     ) {
       fetchEventos()
     }
@@ -95,9 +95,9 @@ export function EventosClientPage({
     // Atualizar URL para refletir o filtro de busca
     const newSearchParams = new URLSearchParams(searchParams.toString())
     if (e.target.value) {
-      newSearchParams.set("title", e.target.value)
+      newSearchParams.set("name", e.target.value)
     } else {
-      newSearchParams.delete("title")
+      newSearchParams.delete("name")
     }
     router.push(`/eventos?${newSearchParams.toString()}`)
   }
@@ -107,9 +107,9 @@ export function EventosClientPage({
     // Atualizar URL para refletir o filtro de data
     const newSearchParams = new URLSearchParams(searchParams.toString())
     if (selectedDate) {
-      newSearchParams.set("date", format(selectedDate, "yyyy-MM-dd"))
+      newSearchParams.set("start_date", format(selectedDate, "yyyy-MM-dd"))
     } else {
-      newSearchParams.delete("date")
+      newSearchParams.delete("start_date")
     }
     router.push(`/eventos?${newSearchParams.toString()}`)
   }

--- a/app/eventos/page.tsx
+++ b/app/eventos/page.tsx
@@ -20,10 +20,10 @@ export default async function EventosPage({
 
   // Extrair filtros dos parâmetros de busca
   const filters: any = {}
-  if (searchParams.title) filters.title = searchParams.title
+  if (searchParams.name) filters.name = searchParams.name
   if (searchParams.city) filters.city = searchParams.city
   if (searchParams.state) filters.state = searchParams.state
-  if (searchParams.date) filters.date = searchParams.date
+  if (searchParams.start_date) filters.start_date = searchParams.start_date
 
   const { data: events, count } = await getEvents(page, pageSize, filters)
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,7 @@ export default async function Home() {
     const adoptionPetsResult = await getPetsForAdoption(1, 4)
     const lostPetsResult = await getLostPets(1, 4)
     const eventsResult = await getEvents(1, 4, {
-      date: new Date().toISOString(),
+      start_date: new Date().toISOString(),
     })
 
     // Extrair os arrays de dados dos resultados paginados


### PR DESCRIPTION
## Summary
- update filters on events page and API to use `name` and `start_date`
- propagate new params in EventosClientPage
- adjust home page to request events with `start_date`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849e410c84c832dbbaffa2dc5ad919d