### PR TITLE
Remove moderation for events and NGOs

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -130,7 +130,7 @@ export async function createOng(ongData: any) {
           ...ongData,
           id: userId,
           type: "ong",
-          is_verified: false,
+          is_verified: true,
           created_at: new Date().toISOString(),
         },
       ])
@@ -581,7 +581,7 @@ export async function createEvent(eventData: EventFormData) {
         {
           ...eventData,
           user_id: session.user.id,
-          status: "pending",
+          status: "approved", // Eventos são publicados automaticamente
           created_at: new Date().toISOString(),
           slug: baseSlug,
         },

--- a/app/actions/auth-actions.ts
+++ b/app/actions/auth-actions.ts
@@ -107,7 +107,7 @@ export async function registerUserAndNgoAction(
           state: ngoData.ngoState,
           postal_code: ngoData.ngoPostalCode || null,
           verification_document_url: ngoData.verificationDocumentUrl || null,
-          is_verified: false, // NGOs start as unverified
+          is_verified: true, // ONGs são verificadas automaticamente
           slug: uniqueSlug,
         })
         .select("id")

--- a/app/admin-alt/ongs/[id]/page.tsx
+++ b/app/admin-alt/ongs/[id]/page.tsx
@@ -78,14 +78,8 @@ export default async function OngDetailPage({ params }: { params: { id: string }
                   <CardTitle className="text-2xl">{ong.name}</CardTitle>
                   <CardDescription>ID: {ong.id}</CardDescription>
                 </div>
-                <Badge
-                  className={
-                    ong.is_ong_verified
-                      ? "bg-green-100 text-green-800 hover:bg-green-100"
-                      : "bg-yellow-100 text-yellow-800 hover:bg-yellow-100"
-                  }
-                >
-                  {ong.is_ong_verified ? "Verificada" : "Pendente"}
+                <Badge className="bg-green-100 text-green-800 hover:bg-green-100">
+                  Cadastrada
                 </Badge>
               </div>
             </CardHeader>
@@ -202,19 +196,7 @@ export default async function OngDetailPage({ params }: { params: { id: string }
               <CardTitle>Ações</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              {!ong.is_ong_verified && (
-                <form
-                  action={async () => {
-                    "use server"
-                    const supabase = createServerComponentClient({ cookies })
-                    await supabase.from("users").update({ is_ong_verified: true }).eq("id", id)
-                  }}
-                >
-                  <Button type="submit" className="w-full">
-                    Verificar ONG
-                  </Button>
-                </form>
-              )}
+              {null}
 
               <Button variant="outline" className="w-full" asChild>
                 <Link href={`/ongs/${ong.slug || ong.id}`} target="_blank">

--- a/app/admin-alt/ongs/page.tsx
+++ b/app/admin-alt/ongs/page.tsx
@@ -10,7 +10,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { CheckCircle, XCircle, Search, MapPin, Mail, Phone } from "lucide-react"
-import { verifyOng } from "@/app/actions"
 
 export const metadata: Metadata = {
   title: "Gerenciar ONGs | PetAdot",
@@ -40,23 +39,15 @@ export default async function AdminOngsPage() {
     redirect("/")
   }
 
-  // Buscar ONGs
-  const { data: pendingOngs, error: pendingOngsError } = await supabase
+  // Buscar todas as ONGs
+  const { data: verifiedOngs, error: ongsError } = await supabase
     .from("users")
     .select("*")
     .eq("type", "ong")
-    .eq("is_ong_verified", false)
-    .order("created_at", { ascending: false })
-
-  const { data: verifiedOngs, error: verifiedOngsError } = await supabase
-    .from("users")
-    .select("*")
-    .eq("type", "ong")
-    .eq("is_ong_verified", true)
     .order("name", { ascending: true })
 
-  if (pendingOngsError || verifiedOngsError) {
-    console.error("Erro ao buscar ONGs:", { pendingOngsError, verifiedOngsError })
+  if (ongsError) {
+    console.error("Erro ao buscar ONGs:", ongsError)
     return (
       <div className="container py-8">
         <h1 className="text-2xl font-bold mb-4">Gerenciar ONGs</h1>
@@ -81,246 +72,59 @@ export default async function AdminOngsPage() {
         </div>
       </div>
 
-      <Tabs defaultValue="pending">
-        <TabsList className="mb-4">
-          <TabsTrigger value="pending">Pendentes ({pendingOngs?.length || 0})</TabsTrigger>
-          <TabsTrigger value="verified">Verificadas ({verifiedOngs?.length || 0})</TabsTrigger>
-          <TabsTrigger value="all">Todas ({(pendingOngs?.length || 0) + (verifiedOngs?.length || 0)})</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="pending">
-          <Card>
-            <CardHeader>
-              <CardTitle>ONGs Pendentes de Verificação</CardTitle>
-              <CardDescription>ONGs que se cadastraram na plataforma e aguardam verificação.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {pendingOngs && pendingOngs.length > 0 ? (
-                <div className="space-y-6">
-                  {pendingOngs.map((ong) => (
-                    <div key={ong.id} className="border p-4 rounded-lg">
-                      <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-4">
-                        <div className="flex gap-4">
-                          {ong.logo_url && (
-                            <div className="relative w-16 h-16 rounded-full overflow-hidden flex-shrink-0">
-                              <Image
-                                src={ong.logo_url || "/placeholder.svg"}
-                                alt={ong.name}
-                                fill
-                                className="object-cover"
-                              />
-                            </div>
-                          )}
-                          <div>
-                            <h3 className="font-medium text-lg">{ong.name}</h3>
-                            <div className="flex items-center text-sm text-muted-foreground mt-1">
-                              <MapPin className="h-3.5 w-3.5 mr-1" />
-                              {ong.city}, {ong.state}
-                            </div>
-                            {ong.email && (
-                              <div className="flex items-center text-sm text-muted-foreground mt-1">
-                                <Mail className="h-3.5 w-3.5 mr-1" />
-                                {ong.email}
-                              </div>
-                            )}
-                            {ong.contact && (
-                              <div className="flex items-center text-sm text-muted-foreground mt-1">
-                                <Phone className="h-3.5 w-3.5 mr-1" />
-                                {ong.contact}
-                              </div>
-                            )}
-                            <div className="mt-2">
-                              <Badge variant="outline">
-                                Cadastrada em {new Date(ong.created_at).toLocaleDateString("pt-BR")}
-                              </Badge>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="flex gap-2 mt-4 md:mt-0">
-                          <form
-                            action={async () => {
-                              "use server"
-                              await verifyOng(ong.id)
-                            }}
-                          >
-                            <Button type="submit" size="sm" className="gap-1">
-                              <CheckCircle className="h-4 w-4" /> Verificar
-                            </Button>
-                          </form>
-                          <Button variant="outline" size="sm" className="gap-1">
-                            <XCircle className="h-4 w-4" /> Rejeitar
-                          </Button>
-                          <Button variant="ghost" size="sm" asChild>
-                            <Link href={`/admin/ongs/${ong.id}`}>Detalhes</Link>
-                          </Button>
-                        </div>
-                      </div>
-                      {ong.description && (
-                        <div className="mt-4">
-                          <p className="text-sm text-muted-foreground">{ong.description}</p>
-                        </div>
-                      )}
+      <div className="space-y-6">
+        {verifiedOngs && verifiedOngs.length > 0 ? (
+          verifiedOngs.map((ong) => (
+            <div key={ong.id} className="border p-4 rounded-lg">
+              <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-4">
+                <div className="flex gap-4">
+                  {ong.logo_url && (
+                    <div className="relative w-16 h-16 rounded-full overflow-hidden flex-shrink-0">
+                      <Image src={ong.logo_url || "/placeholder.svg"} alt={ong.name} fill className="object-cover" />
                     </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-muted-foreground">Não há ONGs pendentes de verificação.</p>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        <TabsContent value="verified">
-          <Card>
-            <CardHeader>
-              <CardTitle>ONGs Verificadas</CardTitle>
-              <CardDescription>ONGs que já foram verificadas e estão ativas na plataforma.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {verifiedOngs && verifiedOngs.length > 0 ? (
-                <div className="space-y-6">
-                  {verifiedOngs.map((ong) => (
-                    <div key={ong.id} className="border p-4 rounded-lg">
-                      <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-4">
-                        <div className="flex gap-4">
-                          {ong.logo_url && (
-                            <div className="relative w-16 h-16 rounded-full overflow-hidden flex-shrink-0">
-                              <Image
-                                src={ong.logo_url || "/placeholder.svg"}
-                                alt={ong.name}
-                                fill
-                                className="object-cover"
-                              />
-                            </div>
-                          )}
-                          <div>
-                            <div className="flex items-center">
-                              <h3 className="font-medium text-lg">{ong.name}</h3>
-                              <Badge className="ml-2 bg-green-100 text-green-800 hover:bg-green-100">Verificada</Badge>
-                            </div>
-                            <div className="flex items-center text-sm text-muted-foreground mt-1">
-                              <MapPin className="h-3.5 w-3.5 mr-1" />
-                              {ong.city}, {ong.state}
-                            </div>
-                            {ong.email && (
-                              <div className="flex items-center text-sm text-muted-foreground mt-1">
-                                <Mail className="h-3.5 w-3.5 mr-1" />
-                                {ong.email}
-                              </div>
-                            )}
-                            {ong.contact && (
-                              <div className="flex items-center text-sm text-muted-foreground mt-1">
-                                <Phone className="h-3.5 w-3.5 mr-1" />
-                                {ong.contact}
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                        <div className="flex gap-2 mt-4 md:mt-0">
-                          <Button variant="outline" size="sm" asChild>
-                            <Link href={`/admin/ongs/${ong.id}`}>Gerenciar</Link>
-                          </Button>
-                          <Button variant="ghost" size="sm" asChild>
-                            <Link href={`/ongs/${ong.id}`} target="_blank">
-                              Ver Perfil
-                            </Link>
-                          </Button>
-                        </div>
-                      </div>
+                  )}
+                  <div>
+                    <h3 className="font-medium text-lg">{ong.name}</h3>
+                    <div className="flex items-center text-sm text-muted-foreground mt-1">
+                      <MapPin className="h-3.5 w-3.5 mr-1" />
+                      {ong.city}, {ong.state}
                     </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-muted-foreground">Não há ONGs verificadas.</p>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        <TabsContent value="all">
-          <Card>
-            <CardHeader>
-              <CardTitle>Todas as ONGs</CardTitle>
-              <CardDescription>Lista completa de ONGs cadastradas na plataforma.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {[...(pendingOngs || []), ...(verifiedOngs || [])].length > 0 ? (
-                <div className="space-y-6">
-                  {[...(pendingOngs || []), ...(verifiedOngs || [])]
-                    .sort((a, b) => a.name.localeCompare(b.name))
-                    .map((ong) => (
-                      <div key={ong.id} className="border p-4 rounded-lg">
-                        <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-4">
-                          <div className="flex gap-4">
-                            {ong.logo_url && (
-                              <div className="relative w-16 h-16 rounded-full overflow-hidden flex-shrink-0">
-                                <Image
-                                  src={ong.logo_url || "/placeholder.svg"}
-                                  alt={ong.name}
-                                  fill
-                                  className="object-cover"
-                                />
-                              </div>
-                            )}
-                            <div>
-                              <div className="flex items-center">
-                                <h3 className="font-medium text-lg">{ong.name}</h3>
-                                {ong.is_verified ? (
-                                  <Badge className="ml-2 bg-green-100 text-green-800 hover:bg-green-100">
-                                    Verificada
-                                  </Badge>
-                                ) : (
-                                  <Badge className="ml-2 bg-yellow-100 text-yellow-800 hover:bg-yellow-100">
-                                    Pendente
-                                  </Badge>
-                                )}
-                              </div>
-                              <div className="flex items-center text-sm text-muted-foreground mt-1">
-                                <MapPin className="h-3.5 w-3.5 mr-1" />
-                                {ong.city}, {ong.state}
-                              </div>
-                              {ong.email && (
-                                <div className="flex items-center text-sm text-muted-foreground mt-1">
-                                  <Mail className="h-3.5 w-3.5 mr-1" />
-                                  {ong.email}
-                                </div>
-                              )}
-                              {ong.contact && (
-                                <div className="flex items-center text-sm text-muted-foreground mt-1">
-                                  <Phone className="h-3.5 w-3.5 mr-1" />
-                                  {ong.contact}
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                          <div className="flex gap-2 mt-4 md:mt-0">
-                            {!ong.is_verified && (
-                              <form
-                                action={async () => {
-                                  "use server"
-                                  await verifyOng(ong.id)
-                                }}
-                              >
-                                <Button type="submit" size="sm" className="gap-1">
-                                  <CheckCircle className="h-4 w-4" /> Verificar
-                                </Button>
-                              </form>
-                            )}
-                            <Button variant="outline" size="sm" asChild>
-                              <Link href={`/admin/ongs/${ong.id}`}>{ong.is_verified ? "Gerenciar" : "Detalhes"}</Link>
-                            </Button>
-                          </div>
-                        </div>
+                    {ong.email && (
+                      <div className="flex items-center text-sm text-muted-foreground mt-1">
+                        <Mail className="h-3.5 w-3.5 mr-1" />
+                        {ong.email}
                       </div>
-                    ))}
+                    )}
+                    {ong.contact && (
+                      <div className="flex items-center text-sm text-muted-foreground mt-1">
+                        <Phone className="h-3.5 w-3.5 mr-1" />
+                        {ong.contact}
+                      </div>
+                    )}
+                  </div>
                 </div>
-              ) : (
-                <p className="text-muted-foreground">Não há ONGs cadastradas.</p>
+                <div className="flex gap-2 mt-4 md:mt-0">
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href={`/admin/ongs/${ong.id}`}>Gerenciar</Link>
+                  </Button>
+                  <Button variant="ghost" size="sm" asChild>
+                    <Link href={`/ongs/${ong.id}`} target="_blank">
+                      Ver Perfil
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+              {ong.description && (
+                <div className="mt-4">
+                  <p className="text-sm text-muted-foreground">{ong.description}</p>
+                </div>
               )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-      </Tabs>
+            </div>
+          ))
+        ) : (
+          <p className="text-muted-foreground">Não há ONGs cadastradas.</p>
+        )}
+      </div>
     </div>
   )
 }

--- a/app/admin/ongs/[id]/page.tsx
+++ b/app/admin/ongs/[id]/page.tsx
@@ -9,7 +9,6 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MapPin, Mail, Phone, Globe, Calendar, PawPrint, CheckCircle, XCircle, ArrowLeft, Trash2 } from "lucide-react"
-import { verifyOng } from "@/app/actions"
 
 export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
   const supabase = createServerComponentClient({ cookies })
@@ -193,19 +192,7 @@ export default async function AdminOngDetailsPage({ params }: { params: { id: st
               </div>
             </CardContent>
             <CardFooter className="flex flex-col sm:flex-row gap-3 border-t pt-6">
-              {!ong.is_verified && (
-                <form
-                  action={async () => {
-                    "use server"
-                    await verifyOng(ong.id)
-                  }}
-                  className="w-full sm:w-auto"
-                >
-                  <Button type="submit" className="w-full gap-1">
-                    <CheckCircle className="h-4 w-4" /> Verificar ONG
-                  </Button>
-                </form>
-              )}
+              {!ong.is_verified && null}
               <Button variant="outline" className="w-full sm:w-auto gap-1">
                 <XCircle className="h-4 w-4" /> Rejeitar ONG
               </Button>
@@ -336,22 +323,11 @@ export default async function AdminOngDetailsPage({ params }: { params: { id: st
               <CardDescription>Gerencie esta ONG</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              {!ong.is_verified ? (
-                <form
-                  action={async () => {
-                    "use server"
-                    await verifyOng(ong.id)
-                  }}
-                >
-                  <Button type="submit" className="w-full gap-1">
-                    <CheckCircle className="h-4 w-4" /> Verificar ONG
-                  </Button>
-                </form>
-              ) : (
+              {ong.is_verified ? (
                 <Button className="w-full gap-1" disabled>
                   <CheckCircle className="h-4 w-4" /> ONG já verificada
                 </Button>
-              )}
+              ) : null}
               <Button variant="outline" className="w-full gap-1">
                 <XCircle className="h-4 w-4" /> Rejeitar ONG
               </Button>

--- a/app/ongs/[slug]/page.tsx
+++ b/app/ongs/[slug]/page.tsx
@@ -50,7 +50,6 @@ export default async function OngPage({ params }: { params: { slug: string } }) 
     .from("ongs")
     .select("*")
     .eq(isUuidValue ? "id" : "slug", slugOrId)
-    .eq("is_verified", true)
     .single()
 
   if (ongError || !ong) {

--- a/app/ongs/dashboard/eventos/cadastrar/page.tsx
+++ b/app/ongs/dashboard/eventos/cadastrar/page.tsx
@@ -84,7 +84,7 @@ export default function CadastrarEventoPage() {
 
       const { error: eventError } = await supabase.from("events").insert({
         ...eventData,
-        status: "pending",
+        status: "approved", // Evento publicado imediatamente
         created_at: new Date().toISOString(),
       })
 

--- a/app/ongs/register/page.tsx
+++ b/app/ongs/register/page.tsx
@@ -153,7 +153,7 @@ export default function OngRegisterPage() {
         contact: formData.contact,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
-        is_verified: false,
+        is_verified: true,
       }
 
       console.log("Dados da ONG a serem inseridos:", ongData)

--- a/lib/mappers.ts
+++ b/lib/mappers.ts
@@ -162,7 +162,7 @@ export function mapEventUIToDB(uiData: EventFormUI): EventFormDB {
     max_participants: max_participants || null,
     is_featured: is_featured || false,
     slug: generateSlug(`${name}-${city || ""}-${state || ""}`), // Gerar slug
-    status: "pending", // Status inicial como pendente para aprovação
+    status: "approved", // Publicado automaticamente sem moderação
     start_date,
     end_date,
     latitude: null, // Preencher se tivermos integração de geolocalização


### PR DESCRIPTION
## Summary
- auto-approve events and skip ONG verification
- remove verification buttons from admin pages
- list all NGOs without approval workflow
- show ONG pages without verification filter

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a45f68118832da70840c68c5c56aa