### PR TITLE
Fix admin events page server component

### DIFF
--- a/app/admin-alt/events/loading.tsx
+++ b/app/admin-alt/events/loading.tsx
@@ -1,3 +1,9 @@
+import { Loader2 } from "lucide-react"
+
 export default function Loading() {
-  return null
+  return (
+    <div className="flex items-center justify-center py-10">
+      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+    </div>
+  )
 }

--- a/app/admin-alt/events/page.tsx
+++ b/app/admin-alt/events/page.tsx
@@ -1,16 +1,23 @@
-"use client"
-
 import { getEvents } from "@/lib/supabase"
-import { EventosClientPage } from "@/app/eventos/EventosClientPage" // Assuming EventosClientPage is a named export
+import { EventosClientPage } from "@/app/eventos/EventosClientPage"
 
 export default async function AdminEventsPage({ searchParams }: { searchParams: { page?: string } }) {
   const page = Number.parseInt(searchParams.page || "1")
-  const { data: events, count } = await getEvents({ page, pageSize: 10 }) // Assuming getEvents returns data and count
+  const {
+    data: initialEvents,
+    count: totalEvents,
+  } = await getEvents(page, 10)
 
   return (
     <div className="container mx-auto py-8">
       <h1 className="text-3xl font-bold mb-6">Gerenciar Eventos</h1>
-      <EventosClientPage events={events} totalCount={count} currentPage={page} />
+      <EventosClientPage
+        initialEvents={initialEvents}
+        totalEvents={totalEvents}
+        currentPage={page}
+        pageSize={10}
+        initialFilters={{}}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- update admin events page to be a server component
- fetch events with `getEvents(page, 10)`
- pass the correct props to `EventosClientPage`
- show a loading spinner while events load

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ac1c2b2a8832d81b48492313b3c29