### PR TITLE
Use EventCard on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import { getPetsForAdoption, getLostPets, getEvents } from "@/lib/supabase"
 import StatsSection from "@/components/stats-section"
 import PetCard from "@/components/PetCard"
 import { OptimizedImage } from "@/components/optimized-image"
+import { EventCard } from "@/components/event-card"
 
 // Desativar completamente o cache para a página inicial durante o desenvolvimento
 export const revalidate = 0 // Revalidate on every request
@@ -145,32 +146,22 @@ export default async function Home() {
           </AnimateOnScroll>
 
           {upcomingEvents.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
               {upcomingEvents.map((event, index) => (
                 <AnimateOnScroll key={event.id} delay={index * 100}>
-                  <div className="bg-white rounded-lg shadow-md overflow-hidden">
-                    <div className="h-48 relative">
-                      <OptimizedImage
-                        src={event.image_url || "/placeholder.svg?height=192&width=384&query=pet+event"}
-                        alt={event.name}
-                        width={384}
-                        height={192}
-                        className="w-full h-full"
-                        objectFit="cover"
-                      />
-                    </div>
-                    <div className="p-4">
-                      <h3 className="font-bold text-lg">{event.name}</h3>
-                      <p className="text-sm text-gray-600">
-                        Data: {new Date(event.start_date).toLocaleDateString("pt-BR")}
-                      </p>
-                      <p className="text-sm text-gray-600">Local: {event.location}</p>
-                      <p className="mt-2 text-sm line-clamp-2">{event.description}</p>
-                      <Button className="mt-3 w-full" asChild>
-                        <Link href={`/eventos/${event.slug || event.id}`}>Ver detalhes</Link>
-                      </Button>
-                    </div>
-                  </div>
+                  <EventCard
+                    id={event.id}
+                    name={event.name}
+                    description={event.description}
+                    image_url={event.image_url}
+                    location={event.location}
+                    city={event.city}
+                    state={event.state}
+                    start_date={event.start_date}
+                    end_date={event.end_date}
+                    event_type={event.event_type}
+                    slug={event.slug}
+                  />
                 </AnimateOnScroll>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- replace hard-coded event display with `<EventCard>` components on the homepage
- add missing import

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ac2c4b8d4832db13ed65866c70282