### PR TITLE
Switch admin ongs to new table

### DIFF
--- a/app/admin/ongs/[id]/delete/delete-ong-form.tsx
+++ b/app/admin/ongs/[id]/delete/delete-ong-form.tsx
@@ -23,7 +23,10 @@ export function AdminDeleteOngForm({ ong, petCount }: { ong: any; petCount: numb
     try {
       // Primeiro excluir todos os pets da ONG
       if (petCount > 0) {
-        const { error: petsDeleteError } = await supabase.from("pets").delete().eq("user_id", ong.id)
+        const { error: petsDeleteError } = await supabase
+          .from("pets")
+          .delete()
+          .eq("ong_id", ong.id)
 
         if (petsDeleteError) {
           console.error("Erro ao excluir pets da ONG:", petsDeleteError)
@@ -34,7 +37,7 @@ export function AdminDeleteOngForm({ ong, petCount }: { ong: any; petCount: numb
       }
 
       // Depois excluir a ONG
-      const { error } = await supabase.from("users").delete().eq("id", ong.id)
+      const { error } = await supabase.from("ongs").delete().eq("id", ong.id)
 
       if (error) {
         console.error("Erro ao excluir ONG:", error)
@@ -112,7 +115,7 @@ export function AdminDeleteOngForm({ ong, petCount }: { ong: any; petCount: numb
               <p className="text-muted-foreground">
                 {ong.city}, {ong.state}
               </p>
-              <p className="text-muted-foreground">Email: {ong.email}</p>
+              <p className="text-muted-foreground">Email: {ong.contact_email}</p>
               {petCount > 0 && (
                 <p className="mt-2 font-medium text-red-600">
                   Esta ONG possui {petCount} {petCount === 1 ? "pet cadastrado" : "pets cadastrados"} que também serão

--- a/app/admin/ongs/[id]/delete/page.tsx
+++ b/app/admin/ongs/[id]/delete/page.tsx
@@ -28,7 +28,13 @@ export default async function DeleteOngPage({ params }: { params: { id: string }
   }
 
   // Buscar detalhes da ONG
-  const { data: ong, error: ongError } = await supabase.from("users").select("*").eq("id", id).single()
+  const { data: ong, error: ongError } = await supabase
+    .from("ongs")
+    .select(
+      "id, user_id, name, city, state, contact_email, contact_phone, mission, cnpj, slug"
+    )
+    .eq("id", id)
+    .single()
 
   if (ongError || !ong) {
     console.error("Erro ao buscar ONG:", ongError)
@@ -36,7 +42,10 @@ export default async function DeleteOngPage({ params }: { params: { id: string }
   }
 
   // Buscar pets da ONG
-  const { data: pets, error: petsError } = await supabase.from("pets").select("id").eq("user_id", id)
+  const { data: pets, error: petsError } = await supabase
+    .from("pets")
+    .select("id")
+    .eq("ong_id", id)
 
   if (petsError) {
     console.error("Erro ao buscar pets da ONG:", petsError)

--- a/app/admin/ongs/[id]/edit/page.tsx
+++ b/app/admin/ongs/[id]/edit/page.tsx
@@ -30,7 +30,11 @@ export default async function EditOngPage({ params }: { params: { id: string } }
   }
 
   // Buscar detalhes da ONG
-  const { data: ong, error: ongError } = await supabase.from("users").select("*").eq("id", id).single()
+  const { data: ong, error: ongError } = await supabase
+    .from("ongs")
+    .select("id, name, city, state, contact_email, contact_phone, mission, cnpj, slug")
+    .eq("id", id)
+    .single()
 
   if (ongError || !ong) {
     console.error("Erro ao buscar ONG:", ongError)

--- a/app/admin/ongs/[id]/page.tsx
+++ b/app/admin/ongs/[id]/page.tsx
@@ -33,7 +33,11 @@ export default async function OngDetailPage({ params }: { params: { id: string }
   }
 
   // Buscar detalhes da ONG
-  const { data: ong, error: ongError } = await supabase.from("users").select("*").eq("id", id).single()
+  const { data: ong, error: ongError } = await supabase
+    .from("ongs")
+    .select("id, user_id, name, city, state, logo_url, contact_email, contact_phone, mission, cnpj, slug, created_at")
+    .eq("id", id)
+    .single()
 
   if (ongError || !ong) {
     console.error("Erro ao buscar ONG:", ongError)
@@ -44,7 +48,7 @@ export default async function OngDetailPage({ params }: { params: { id: string }
   const { data: pets, error: petsError } = await supabase
     .from("pets")
     .select("id, name, species, breed, category, status, main_image_url")
-    .eq("user_id", id)
+    .eq("ong_id", id)
     .order("created_at", { ascending: false })
 
   if (petsError) {
@@ -101,11 +105,11 @@ export default async function OngDetailPage({ params }: { params: { id: string }
                   </div>
                   <div className="flex items-center">
                     <MailIcon className="h-4 w-4 mr-2 text-muted-foreground" />
-                    <span>{ong.email}</span>
+                    <span>{ong.contact_email}</span>
                   </div>
                   <div className="flex items-center">
                     <PhoneIcon className="h-4 w-4 mr-2 text-muted-foreground" />
-                    <span>{ong.contact || "Não informado"}</span>
+                    <span>{ong.contact_phone || "Não informado"}</span>
                   </div>
                   <div className="flex items-center">
                     <ClockIcon className="h-4 w-4 mr-2 text-muted-foreground" />
@@ -114,10 +118,10 @@ export default async function OngDetailPage({ params }: { params: { id: string }
                 </div>
               </div>
 
-              {ong.description && (
+              {ong.mission && (
                 <div>
                   <h3 className="font-medium mb-2">Descrição</h3>
-                  <p className="text-muted-foreground whitespace-pre-wrap">{ong.description}</p>
+                  <p className="text-muted-foreground whitespace-pre-wrap">{ong.mission}</p>
                 </div>
               )}
 

--- a/app/admin/ongs/page.tsx
+++ b/app/admin/ongs/page.tsx
@@ -41,9 +41,10 @@ export default async function AdminOngsPage() {
 
   // Buscar todas as ONGs
   const { data: verifiedOngs, error: ongsError } = await supabase
-    .from("users")
-    .select("*")
-    .eq("type", "ong")
+    .from("ongs")
+    .select(
+      "id, name, city, state, logo_url, contact_email, contact_phone, mission, slug"
+    )
     .order("name", { ascending: true })
 
   if (ongsError) {
@@ -89,16 +90,16 @@ export default async function AdminOngsPage() {
                       <MapPin className="h-3.5 w-3.5 mr-1" />
                       {ong.city}, {ong.state}
                     </div>
-                    {ong.email && (
+                    {ong.contact_email && (
                       <div className="flex items-center text-sm text-muted-foreground mt-1">
                         <Mail className="h-3.5 w-3.5 mr-1" />
-                        {ong.email}
+                        {ong.contact_email}
                       </div>
                     )}
-                    {ong.contact && (
+                    {ong.contact_phone && (
                       <div className="flex items-center text-sm text-muted-foreground mt-1">
                         <Phone className="h-3.5 w-3.5 mr-1" />
-                        {ong.contact}
+                        {ong.contact_phone}
                       </div>
                     )}
                   </div>
@@ -114,9 +115,9 @@ export default async function AdminOngsPage() {
                   </Button>
                 </div>
               </div>
-              {ong.description && (
+              {ong.mission && (
                 <div className="mt-4">
-                  <p className="text-sm text-muted-foreground">{ong.description}</p>
+                  <p className="text-sm text-muted-foreground">{ong.mission}</p>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- query `ongs` instead of `users` for admin ONG pages
- update fields to match the `ongs` schema
- fetch pets by `ong_id` and adjust delete logic

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684adbce25b8832dbcb7ebdd28c5f13e