### PR TITLE
Add admin ongs loading spinner

### DIFF
--- a/app/admin/ongs/loading.tsx
+++ b/app/admin/ongs/loading.tsx
@@ -1,3 +1,9 @@
+import { Loader2 } from "lucide-react"
+
 export default function Loading() {
-  return null
+  return (
+    <div className="flex items-center justify-center py-10">
+      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- show a centered spinner while admin ONGs page loads

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b726887a0832d9ac218a566c2def7