### PR TITLE
Add delete button for admin event cards

### DIFF
--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -17,6 +17,7 @@ export default async function AdminEventsPage({ searchParams }: { searchParams: 
         currentPage={page}
         pageSize={10}
         initialFilters={{}}
+        adminView
       />
     </div>
   )

--- a/app/eventos/EventosClientPage.tsx
+++ b/app/eventos/EventosClientPage.tsx
@@ -39,6 +39,7 @@ interface EventosClientPageProps {
     state?: string
     start_date?: string
   }
+  adminView?: boolean
 }
 
 export function EventosClientPage({
@@ -48,6 +49,7 @@ export function EventosClientPage({
   currentPage,
   pageSize,
   initialFilters,
+  adminView = false,
 }: EventosClientPageProps) {
   const [eventos, setEventos] = useState<Evento[]>(initialEvents)
   const [search, setSearch] = useState(initialFilters.name || "")
@@ -214,7 +216,7 @@ export function EventosClientPage({
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {eventos.map((evento) => (
-            <EventCard key={evento.id} {...evento} />
+            <EventCard key={evento.id} {...evento} showDeleteButton={adminView} />
           ))}
         </div>
       )}

--- a/components/event-card.tsx
+++ b/components/event-card.tsx
@@ -18,6 +18,8 @@ interface EventCardProps {
   end_date?: string
   event_type?: string
   slug?: string
+  /** Mostrar botão de exclusão (para admins) */
+  showDeleteButton?: boolean
 }
 
 export function EventCard({
@@ -33,12 +35,59 @@ export function EventCard({
   end_date,
   event_type,
   slug,
+  showDeleteButton = false,
 }: EventCardProps) {
   const displayLocation = location || (city && state ? `${city}, ${state}` : city || state)
   const displayDate = formatDateTime(start_date)
   const displayEventType = mapEventType(event_type)
 
   const detailUrl = slug ? `/eventos/${slug}` : `/eventos/${id}`
+  if (showDeleteButton) {
+    return (
+      <Card className="overflow-hidden h-full flex flex-col hover:shadow-lg transition-shadow duration-200">
+        <Link href={detailUrl} className="block">
+          <div className="relative w-full h-48">
+            <Image
+              src={image_url || "/placeholder.svg?height=192&width=384&text=Evento"}
+              alt={name}
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              priority={false}
+              unoptimized={image_url?.includes("placeholder.svg")}
+            />
+            {event_type && (
+              <Badge className="absolute top-2 left-2 bg-primary text-primary-foreground">{displayEventType}</Badge>
+            )}
+          </div>
+        </Link>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-xl font-bold line-clamp-2">{name}</CardTitle>
+          <CardDescription className="flex items-center gap-1 text-sm">
+            <CalendarDays className="w-4 h-4" />
+            {displayDate}
+          </CardDescription>
+          {displayLocation && (
+            <CardDescription className="flex items-center gap-1 text-sm">
+              <MapPin className="w-4 h-4" />
+              {displayLocation}
+            </CardDescription>
+          )}
+        </CardHeader>
+        <CardContent className="flex-grow">
+          <p className="text-sm text-muted-foreground line-clamp-3">{description}</p>
+        </CardContent>
+        <CardFooter className="justify-between">
+          <Button variant="outline" asChild>
+            <Link href={detailUrl}>Ver Detalhes</Link>
+          </Button>
+          <Button variant="destructive" size="sm" asChild>
+            <Link href={`/admin/events/${id}/delete`}>Excluir</Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    )
+  }
 
   return (
     <Link href={detailUrl} className="block">


### PR DESCRIPTION
## Summary
- show optional delete button in `EventCard`
- allow `EventosClientPage` to pass through `adminView` flag
- render event delete actions on the admin events page

## Testing
- `pnpm lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_b_684b94959fd0832d8ddde7cac17a02dd