### PR TITLE
Update Supabase client usage

### DIFF
--- a/lib/storage-manager.ts
+++ b/lib/storage-manager.ts
@@ -1,12 +1,10 @@
 "use client"
 
-import { createClient } from "@supabase/supabase-js"
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
 import { v4 as uuidv4 } from "uuid"
 
 // Configuração do Supabase
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ""
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+const supabase = createClientComponentClient()
 
 // Nome do bucket principal
 const BUCKET_NAME = "petadot-images"


### PR DESCRIPTION
## Summary
- use `createClientComponentClient` from auth helpers in `storage-manager`
- remove redundant `supabaseUrl` and `supabaseAnonKey` constants

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ce8db8be4832d9c20303835268356