### PR TITLE
Fix storage policy folder index

### DIFF
--- a/app/api/storage/setup/route.ts
+++ b/app/api/storage/setup/route.ts
@@ -68,7 +68,7 @@ export async function POST() {
         await supabase.rpc("create_storage_policy", {
           bucket_id: BUCKET_NAME,
           policy_name: "Owner Update",
-          definition: "bucket_id = '" + BUCKET_NAME + "' AND auth.uid()::text = (storage.foldername(name))[1]",
+          definition: "bucket_id = '" + BUCKET_NAME + "' AND auth.uid()::text = (storage.foldername(name))[2]",
           policy_operation: "UPDATE",
         })
 
@@ -76,7 +76,7 @@ export async function POST() {
         await supabase.rpc("create_storage_policy", {
           bucket_id: BUCKET_NAME,
           policy_name: "Owner Delete",
-          definition: "bucket_id = '" + BUCKET_NAME + "' AND auth.uid()::text = (storage.foldername(name))[1]",
+          definition: "bucket_id = '" + BUCKET_NAME + "' AND auth.uid()::text = (storage.foldername(name))[2]",
           policy_operation: "DELETE",
         })
 

--- a/db/create-storage-bucket.sql
+++ b/db/create-storage-bucket.sql
@@ -13,11 +13,11 @@ WITH CHECK (bucket_id = 'petadot-images' AND auth.role() = 'authenticated');
 
 -- Permitir que usuários atualizem suas próprias imagens
 CREATE POLICY "Users can update own images" ON storage.objects FOR UPDATE 
-USING (bucket_id = 'petadot-images' AND auth.uid()::text = (storage.foldername(name))[1]);
+USING (bucket_id = 'petadot-images' AND auth.uid()::text = (storage.foldername(name))[2]);
 
 -- Permitir que usuários deletem suas próprias imagens
 CREATE POLICY "Users can delete own images" ON storage.objects FOR DELETE 
-USING (bucket_id = 'petadot-images' AND auth.uid()::text = (storage.foldername(name))[1]);
+USING (bucket_id = 'petadot-images' AND auth.uid()::text = (storage.foldername(name))[2]);
 
 -- Verificar se o bucket foi criado
 SELECT * FROM storage.buckets WHERE id = 'petadot-images';


### PR DESCRIPTION
## Summary
- update storage policy folder index to use second path segment
- ensure API setup uses correct segment

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ce9f37a14832d87f20ba18e148dc4