### PR TITLE
Redirect dashboard pets to my-pets

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -328,7 +328,7 @@ export async function createAdoptionPet(petData: any) {
 
     // Revalidar página de adoção
     revalidatePath("/adocao")
-    revalidatePath("/dashboard/pets")
+    revalidatePath("/my-pets")
 
     return { success: true, pet }
   } catch (error: any) {
@@ -418,7 +418,7 @@ export async function createLostPet(petData: any) {
 
     // Revalidar página de pets perdidos
     revalidatePath("/perdidos")
-    revalidatePath("/dashboard/pets")
+    revalidatePath("/my-pets")
 
     return { success: true, data }
   } catch (error: any) {
@@ -508,7 +508,7 @@ export async function createFoundPet(petData: any) {
 
     // Revalidar página de pets encontrados
     revalidatePath("/encontrados")
-    revalidatePath("/dashboard/pets")
+    revalidatePath("/my-pets")
 
     return { success: true, data }
   } catch (error: any) {

--- a/app/actions/found-pet-actions.ts
+++ b/app/actions/found-pet-actions.ts
@@ -175,7 +175,7 @@ export async function createFoundPet(formData: FormData) {
 
     // Revalidar páginas
     revalidatePath("/encontrados")
-    revalidatePath("/dashboard/pets")
+    revalidatePath("/my-pets")
     revalidatePath("/admin/moderation")
 
     if (blocked) {

--- a/app/actions/pet-actions.ts
+++ b/app/actions/pet-actions.ts
@@ -276,7 +276,7 @@ export async function createAdoptionPet(petData: any) {
       // Revalidar as páginas relacionadas
       revalidatePath("/adocao")
       revalidatePath(`/adocao/${petData.id}`)
-      revalidatePath("/dashboard/pets")
+      revalidatePath("/my-pets")
 
       return { success: true }
     }
@@ -355,7 +355,7 @@ export async function createAdoptionPet(petData: any) {
 
     // Revalidar as páginas relacionadas
     revalidatePath("/adocao")
-    revalidatePath("/dashboard/pets")
+    revalidatePath("/my-pets")
 
     return { success: true, data: insertedPet }
   } catch (error) {

--- a/app/actions/pet-status.ts
+++ b/app/actions/pet-status.ts
@@ -96,7 +96,7 @@ export async function updatePetStatus(
     console.log("Pet atualizado com sucesso")
 
     // Revalidar páginas relevantes
-    revalidatePath("/dashboard/pets")
+    revalidatePath("/my-pets")
     revalidatePath("/admin/pets")
     revalidatePath("/")
 

--- a/app/actions/success-story-actions.ts
+++ b/app/actions/success-story-actions.ts
@@ -73,7 +73,7 @@ export async function createSuccessStory(formData: FormData) {
     // Revalidar caminhos relevantes
     revalidatePath("/historias")
     revalidatePath(`/historias/${data[0].id}`)
-    revalidatePath("/dashboard/pets")
+    revalidatePath("/my-pets")
 
     return { success: true, data: data[0] }
   } catch (error) {

--- a/app/api/pets/adoption/route.ts
+++ b/app/api/pets/adoption/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
       // Revalidar as páginas relacionadas
       revalidatePath("/adocao")
       revalidatePath(`/adocao/${petData.id}`)
-      revalidatePath("/dashboard/pets")
+      revalidatePath("/my-pets")
 
       return NextResponse.json({ success: true })
     }
@@ -96,7 +96,7 @@ export async function POST(request: NextRequest) {
 
     // Revalidar as páginas relacionadas
     revalidatePath("/adocao")
-    revalidatePath("/dashboard/pets")
+    revalidatePath("/my-pets")
 
     return NextResponse.json({ success: true, data: insertedPet })
   } catch (error) {

--- a/app/api/success-stories/route.ts
+++ b/app/api/success-stories/route.ts
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
     // Revalidar caminhos relevantes
     revalidatePath("/historias")
     revalidatePath(`/historias/${data[0].id}`)
-    revalidatePath("/dashboard/pets")
+    revalidatePath("/my-pets")
 
     return NextResponse.json({ success: true, id: data[0].id })
   } catch (error) {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -250,7 +250,7 @@ function DashboardContent() {
             </CardContent>
             <CardFooter>
               <Button variant="outline" className="w-full" asChild>
-                <Link href="/dashboard/pets">
+                <Link href="/my-pets">
                   Ver Todos os Pets
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Link>

--- a/app/dashboard/pets/[type]/[id]/delete/page.tsx
+++ b/app/dashboard/pets/[type]/[id]/delete/page.tsx
@@ -120,11 +120,11 @@ function DeletePetContent({ params }: { params: { type: string; id: string } }) 
         })
 
         // Adicionar um parâmetro de timestamp para forçar a atualização da página
-        router.push(`/dashboard/pets?t=${Date.now()}`)
+        router.push(`/my-pets?t=${Date.now()}`)
 
         // Forçar uma atualização completa da página após um breve atraso
         setTimeout(() => {
-          window.location.href = `/dashboard/pets?refresh=${Date.now()}`
+          window.location.href = `/my-pets?refresh=${Date.now()}`
         }, 500)
       } else {
         toast({
@@ -162,7 +162,7 @@ function DeletePetContent({ params }: { params: { type: string; id: string } }) 
   return (
     <div className="container py-8 md:py-12">
       <Button variant="ghost" className="mb-6" asChild>
-        <Link href="/dashboard/pets">
+        <Link href="/my-pets">
           <ArrowLeft className="mr-2 h-4 w-4" />
           Voltar para Meus Pets
         </Link>
@@ -192,7 +192,7 @@ function DeletePetContent({ params }: { params: { type: string; id: string } }) 
           </CardHeader>
           <CardFooter>
             <Button asChild className="w-full">
-              <Link href="/dashboard/pets">Voltar para Meus Pets</Link>
+              <Link href="/my-pets">Voltar para Meus Pets</Link>
             </Button>
           </CardFooter>
         </Card>
@@ -236,7 +236,7 @@ function DeletePetContent({ params }: { params: { type: string; id: string } }) 
           </CardContent>
           <CardFooter className="flex justify-between">
             <Button variant="outline" asChild>
-              <Link href="/dashboard/pets">Cancelar</Link>
+              <Link href="/my-pets">Cancelar</Link>
             </Button>
             <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
               {isDeleting ? (

--- a/app/dashboard/pets/[type]/[id]/edit/page.tsx
+++ b/app/dashboard/pets/[type]/[id]/edit/page.tsx
@@ -92,7 +92,7 @@ function EditPet({ type, id }: { type: string; id: string }) {
       title: "Pet atualizado com sucesso",
       description: "As informações do pet foram atualizadas com sucesso.",
     })
-    router.push("/dashboard/pets")
+    router.push("/my-pets")
   }
 
   const handleError = (message: string) => {
@@ -121,7 +121,7 @@ function EditPet({ type, id }: { type: string; id: string }) {
           </CardHeader>
           <CardContent>
             <p className="text-destructive">{error}</p>
-            <Button className="mt-4" onClick={() => router.push("/dashboard/pets")}>
+            <Button className="mt-4" onClick={() => router.push("/my-pets")}>
               Voltar para Meus Pets
             </Button>
           </CardContent>
@@ -139,7 +139,7 @@ function EditPet({ type, id }: { type: string; id: string }) {
             <CardDescription>O pet que você está procurando não foi encontrado.</CardDescription>
           </CardHeader>
           <CardContent>
-            <Button onClick={() => router.push("/dashboard/pets")}>Voltar para Meus Pets</Button>
+            <Button onClick={() => router.push("/my-pets")}>Voltar para Meus Pets</Button>
           </CardContent>
         </Card>
       </div>

--- a/app/dashboard/pets/adoption/[id]/delete/page.tsx
+++ b/app/dashboard/pets/adoption/[id]/delete/page.tsx
@@ -74,7 +74,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           title: "Pet excluído com sucesso",
           description: "O pet foi excluído permanentemente.",
         })
-        router.push("/dashboard/pets")
+        router.push("/my-pets")
       } else {
         toast({
           title: "Erro ao excluir pet",
@@ -97,7 +97,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
   return (
     <div className="container py-8 md:py-12">
       <Button variant="ghost" className="mb-6" asChild>
-        <Link href="/dashboard/pets">
+        <Link href="/my-pets">
           <ArrowLeft className="mr-2 h-4 w-4" />
           Voltar para Meus Pets
         </Link>
@@ -127,7 +127,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           </CardHeader>
           <CardFooter>
             <Button asChild className="w-full">
-              <Link href="/dashboard/pets">Voltar para Meus Pets</Link>
+              <Link href="/my-pets">Voltar para Meus Pets</Link>
             </Button>
           </CardFooter>
         </Card>
@@ -158,7 +158,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           </CardContent>
           <CardFooter className="flex justify-between">
             <Button variant="outline" asChild>
-              <Link href="/dashboard/pets">Cancelar</Link>
+              <Link href="/my-pets">Cancelar</Link>
             </Button>
             <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
               {isDeleting ? (

--- a/app/dashboard/pets/found/[id]/delete/page.tsx
+++ b/app/dashboard/pets/found/[id]/delete/page.tsx
@@ -74,7 +74,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           title: "Pet excluído com sucesso",
           description: "O pet foi excluído permanentemente.",
         })
-        router.push("/dashboard/pets")
+        router.push("/my-pets")
       } else {
         toast({
           title: "Erro ao excluir pet",
@@ -97,7 +97,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
   return (
     <div className="container py-8 md:py-12">
       <Button variant="ghost" className="mb-6" asChild>
-        <Link href="/dashboard/pets">
+        <Link href="/my-pets">
           <ArrowLeft className="mr-2 h-4 w-4" />
           Voltar para Meus Pets
         </Link>
@@ -127,7 +127,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           </CardHeader>
           <CardFooter>
             <Button asChild className="w-full">
-              <Link href="/dashboard/pets">Voltar para Meus Pets</Link>
+              <Link href="/my-pets">Voltar para Meus Pets</Link>
             </Button>
           </CardFooter>
         </Card>
@@ -156,7 +156,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           </CardContent>
           <CardFooter className="flex justify-between">
             <Button variant="outline" asChild>
-              <Link href="/dashboard/pets">Cancelar</Link>
+              <Link href="/my-pets">Cancelar</Link>
             </Button>
             <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
               {isDeleting ? (

--- a/app/dashboard/pets/lost/[id]/delete/page.tsx
+++ b/app/dashboard/pets/lost/[id]/delete/page.tsx
@@ -74,7 +74,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           title: "Pet excluído com sucesso",
           description: "O pet foi excluído permanentemente.",
         })
-        router.push("/dashboard/pets")
+        router.push("/my-pets")
       } else {
         toast({
           title: "Erro ao excluir pet",
@@ -97,7 +97,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
   return (
     <div className="container py-8 md:py-12">
       <Button variant="ghost" className="mb-6" asChild>
-        <Link href="/dashboard/pets">
+        <Link href="/my-pets">
           <ArrowLeft className="mr-2 h-4 w-4" />
           Voltar para Meus Pets
         </Link>
@@ -127,7 +127,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           </CardHeader>
           <CardFooter>
             <Button asChild className="w-full">
-              <Link href="/dashboard/pets">Voltar para Meus Pets</Link>
+              <Link href="/my-pets">Voltar para Meus Pets</Link>
             </Button>
           </CardFooter>
         </Card>
@@ -156,7 +156,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
           </CardContent>
           <CardFooter className="flex justify-between">
             <Button variant="outline" asChild>
-              <Link href="/dashboard/pets">Cancelar</Link>
+              <Link href="/my-pets">Cancelar</Link>
             </Button>
             <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
               {isDeleting ? (

--- a/app/dashboard/pets/lost/[id]/edit/page.tsx
+++ b/app/dashboard/pets/lost/[id]/edit/page.tsx
@@ -59,7 +59,7 @@ function EditLostPetForm({ id }: { id: string }) {
             description: "O pet que você está tentando editar não foi encontrado.",
             variant: "destructive",
           })
-          router.push("/dashboard/pets")
+          router.push("/my-pets")
           return
         }
 
@@ -70,7 +70,7 @@ function EditLostPetForm({ id }: { id: string }) {
             description: "Você não tem permissão para editar este pet.",
             variant: "destructive",
           })
-          router.push("/dashboard/pets")
+          router.push("/my-pets")
           return
         }
 
@@ -155,7 +155,7 @@ function EditLostPetForm({ id }: { id: string }) {
         description: "As informações do pet foram atualizadas com sucesso.",
       })
 
-      router.push("/dashboard/pets")
+      router.push("/my-pets")
     } catch (error) {
       console.error("Erro ao atualizar pet:", error)
       toast({
@@ -184,7 +184,7 @@ function EditLostPetForm({ id }: { id: string }) {
           <h2 className="text-xl font-semibold mb-2">Pet não encontrado</h2>
           <p className="text-gray-500 mb-4">O pet que você está tentando editar não foi encontrado.</p>
           <Button asChild>
-            <a href="/dashboard/pets">Voltar para Meus Pets</a>
+            <a href="/my-pets">Voltar para Meus Pets</a>
           </Button>
         </div>
       </div>

--- a/app/dashboard/pets/lost/[id]/page.tsx
+++ b/app/dashboard/pets/lost/[id]/page.tsx
@@ -76,7 +76,7 @@ function LostPetDetails({ id }: { id: string }) {
           title: "Pet excluído com sucesso",
           description: "O pet foi excluído permanentemente.",
         })
-        router.push("/dashboard/pets")
+        router.push("/my-pets")
       } else {
         toast({
           title: "Erro ao excluir pet",
@@ -107,7 +107,7 @@ function LostPetDetails({ id }: { id: string }) {
   return (
     <div className="container py-8">
       <Button variant="ghost" className="mb-6" asChild>
-        <Link href="/dashboard/pets">
+        <Link href="/my-pets">
           <ArrowLeft className="mr-2 h-4 w-4" />
           Voltar para Meus Pets
         </Link>

--- a/app/dashboard/pets/page.tsx
+++ b/app/dashboard/pets/page.tsx
@@ -1,10 +1,5 @@
-const PetsPage = () => {
-  return (
-    <div>
-      <h1>Pets Dashboard</h1>
-      {/* Add your pet management UI here */}
-    </div>
-  )
-}
+import { redirect } from "next/navigation"
 
-export default PetsPage
+export default function DashboardPetsPage() {
+  redirect("/my-pets")
+}

--- a/app/perdidos/cadastrar/form-container-basic.tsx
+++ b/app/perdidos/cadastrar/form-container-basic.tsx
@@ -184,7 +184,7 @@ export default function BasicFormContainer() {
       }
 
       alert("Pet reportado com sucesso!")
-      router.push("/dashboard/pets")
+      router.push("/my-pets")
       router.refresh()
     } catch (err: any) {
       console.error("Erro ao salvar pet perdido:", err)

--- a/app/perdidos/cadastrar/form-container-simple.tsx
+++ b/app/perdidos/cadastrar/form-container-simple.tsx
@@ -122,7 +122,7 @@ export default function SimpleFormContainer() {
       }
 
       alert("Pet reportado com sucesso!")
-      router.push("/dashboard/pets")
+      router.push("/my-pets")
       router.refresh()
     } catch (err: any) {
       console.error("Erro ao salvar pet perdido:", err)

--- a/components/LostPetForm.tsx
+++ b/components/LostPetForm.tsx
@@ -249,7 +249,7 @@ export function LostPetForm({ initialData, isEditing = false }: LostPetFormProps
 
         // Aguardar 2 segundos antes de redirecionar
         setTimeout(() => {
-          router.push("/dashboard/pets")
+          router.push("/my-pets")
           router.refresh()
         }, 2000)
       } else {

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -497,7 +497,7 @@ export default function Navbar() {
                   <Link href="/dashboard">Dashboard</Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
-                  <Link href="/dashboard/pets">Meus Pets</Link>
+                  <Link href="/my-pets">Meus Pets</Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
                   <Link href="/dashboard/profile">Meu Perfil</Link>


### PR DESCRIPTION
## Summary
- update the "Meus Pets" dropdown link
- redirect `/dashboard/pets` to `/my-pets`
- refresh `/my-pets` after actions and deletions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684cf791d1c4832dafddc3e098fa8c5a