### PR TITLE
Publish pets immediately

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -380,7 +380,7 @@ export async function createLostPet(petData: any) {
       ...petData,
       user_id: userId,
       category: "lost", // Add category field
-      status: "pending",
+      status: "approved",
       created_at: new Date().toISOString(),
       slug: baseSlug,
     }
@@ -470,7 +470,7 @@ export async function createFoundPet(petData: any) {
       ...petData,
       user_id: userId,
       category: "found", // Add category field
-      status: "pending",
+      status: "approved",
       created_at: new Date().toISOString(),
       slug: baseSlug,
     }
@@ -1024,7 +1024,7 @@ export async function createPet(formData: FormData) {
           adoption_requirements,
           image_url,
           additional_images,
-          status: "pending",
+          status: "available",
           user_id: session.user.id,
           location,
           city,

--- a/app/actions/pet-actions.ts
+++ b/app/actions/pet-actions.ts
@@ -77,7 +77,7 @@ export async function createLostPet(formData: FormData) {
           good_with_dogs,
           is_vaccinated,
           is_neutered,
-          status: "pending",
+          status: "approved",
           category: "lost",
         },
       ])
@@ -190,7 +190,7 @@ export async function createFoundPet(formData: FormData) {
           good_with_dogs,
           is_vaccinated,
           is_neutered,
-          status: "pending",
+          status: "approved",
           category: "found",
         },
       ])
@@ -312,7 +312,7 @@ export async function createAdoptionPet(petData: any) {
       contact: petData.contact,
       user_id: user.id,
       ong_id: petData.ong_id,
-      status: "pending",
+      status: "available",
       category: "adoption",
       created_at: new Date().toISOString(),
     }

--- a/app/adocao/AdocaoClientPage.tsx
+++ b/app/adocao/AdocaoClientPage.tsx
@@ -37,7 +37,7 @@ export default function AdocaoClientPage({
         let query = supabase
           .from("pets")
           .select("*", { count: "exact" })
-          .eq("status", "approved")
+          .eq("status", "available")
 
         // Aplicar filtros
         if (filters.species) {

--- a/components/FoundPetForm.tsx
+++ b/components/FoundPetForm.tsx
@@ -77,7 +77,7 @@ const defaultFoundPetData: FoundPetData = {
   good_with_dogs: false,
   is_vaccinated: false,
   is_neutered: false,
-  status: "pending",
+  status: "approved",
   state: "",
   city: "",
 }
@@ -257,7 +257,7 @@ function FoundPetForm({ initialData, isEditing = false }: FoundPetFormProps) {
       const contentToCheck = `${petData.name || ""} ${petData.description || ""} ${petData.found_location || ""} ${petData.current_location || ""}`
       const { blocked, keyword } = await checkForBlockedKeywords(contentToCheck, supabase)
 
-      let finalStatus = "pending"
+      let finalStatus = "approved"
       let finalRejectionReason = null
 
       if (blocked && keyword) {
@@ -317,7 +317,7 @@ function FoundPetForm({ initialData, isEditing = false }: FoundPetFormProps) {
       } else {
         toast({
           title: "Pet reportado",
-          description: "O pet encontrado foi reportado com sucesso e está aguardando aprovação!",
+          description: "O pet encontrado foi reportado com sucesso!",
         })
       }
 
@@ -344,7 +344,7 @@ function FoundPetForm({ initialData, isEditing = false }: FoundPetFormProps) {
         <Alert className="bg-green-50 border-green-200 mb-4">
           <AlertCircle className="h-4 w-4 text-green-600" />
           <AlertDescription className="text-green-700">
-            Pet reportado com sucesso! Aguardando aprovação da moderação. Você será redirecionado em instantes...
+            Pet reportado com sucesso! Você será redirecionado em instantes...
           </AlertDescription>
         </Alert>
       )}

--- a/components/LostPetForm.tsx
+++ b/components/LostPetForm.tsx
@@ -75,7 +75,7 @@ const defaultLostPetData: LostPetData = {
   good_with_dogs: false,
   is_vaccinated: false,
   is_neutered: false,
-  status: "pending",
+  status: "approved",
   state: "",
   city: "",
 }

--- a/components/PetForm.tsx
+++ b/components/PetForm.tsx
@@ -76,7 +76,7 @@ export default function PetForm({ initialData, onSubmit, isSubmitting, type }: P
       is_vaccinated: false,
       is_special_needs: false,
       special_needs_description: "",
-      status: type === "adoption" ? "available" : "pending", // Default status based on type
+      status: type === "adoption" ? "available" : "approved", // Default status based on type
     },
   })
 

--- a/components/pet-card.tsx
+++ b/components/pet-card.tsx
@@ -224,11 +224,6 @@ export default function PetCard({
                 <span className="font-medium">Gênero:</span> {genderDisplay}
               </p>
             )}
-            {isPending && isOwner && (
-              <p className="mt-2 text-yellow-400 text-xs">
-                Este pet está aguardando aprovação e só é visível para você.
-              </p>
-            )}
           </div>
         </CardContent>
         {isOwner && (

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -87,8 +87,8 @@ export async function getPetsForAdoption(page = 1, pageSize = 12, filters = {}):
       .from("pets")
       .select(`*, ongs(id, name, logo_url, city)`, { count: "exact" })
       .eq("category", "adoption") // Filter for adoption pets
-      // Mostrar apenas pets aprovados
-      .eq("status", "approved")
+      // Mostrar apenas pets disponíveis
+      .eq("status", "available")
       .order("created_at", { ascending: false })
       .range(from, to)
 


### PR DESCRIPTION
## Summary
- publish lost and found pets as approved automatically
- publish adoption pets with status available
- adjust forms to use new statuses
- remove the "aguardando aprovação" notice
- query adoption pets by available status

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684cfcb35998832db50b81d6bd273593