### PR TITLE
Use useAuth in FoundPetForm

### DIFF
--- a/components/FoundPetForm.tsx
+++ b/components/FoundPetForm.tsx
@@ -16,7 +16,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { AlertCircle, XCircle } from "lucide-react"
 import ImageUpload from "./ImageUpload" // Importação padrão
 import { SimpleLocationSelector } from "./simple-location-selector"
-import { useUser } from "@supabase/auth-helpers-react" // Importar useUser
+import { useAuth } from "@/app/auth-provider"
 import { speciesEnum, petSizeEnum } from "@/lib/validators/animal" // Importar enums do validador
 
 interface FoundPetData {
@@ -137,7 +137,7 @@ function FoundPetForm({ initialData, isEditing = false }: FoundPetFormProps) {
   const [rejectionReason, setRejectionReason] = useState("")
   const router = useRouter()
   const supabase = createClientComponentClient()
-  const { user } = useUser() // Obtenha o usuário autenticado aqui
+  const { user } = useAuth()
 
   useEffect(() => {
     if (initialData) {


### PR DESCRIPTION
## Summary
- switch FoundPetForm to use `useAuth`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e01327b74832d8a2af38dd885d914