### PR TITLE
Auto-approve pet submissions

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -290,7 +290,7 @@ export async function createAdoptionPet(petData: any) {
       ...petData,
       user_id: userId,
       category: "adoption", // Add category field
-      status: ongData ? "approved" : "pending", // Se for ONG, aprova automaticamente
+      status: "approved",
       created_at: new Date().toISOString(),
       slug: baseSlug,
     }

--- a/app/actions/found-pet-actions.ts
+++ b/app/actions/found-pet-actions.ts
@@ -111,7 +111,7 @@ export async function createFoundPet(formData: FormData) {
     const contentToCheck = `${name || ""} ${description || ""} ${found_location || ""} ${current_location || ""}`
     const { blocked, keyword } = await checkContentForBlockedKeywords(contentToCheck, supabase)
 
-    let status = "pending"
+    let status = "approved"
     let rejection_reason = null
 
     if (blocked) {

--- a/app/api/pets/adoption/route.ts
+++ b/app/api/pets/adoption/route.ts
@@ -54,7 +54,7 @@ export async function POST(request: NextRequest) {
     const newPet = {
       ...petData,
       user_id: session.user.id,
-      status: "pending",
+      status: "approved",
       created_at: new Date().toISOString(),
     }
 

--- a/app/perdidos/cadastrar/form-container-basic.tsx
+++ b/app/perdidos/cadastrar/form-container-basic.tsx
@@ -162,7 +162,7 @@ export default function BasicFormContainer() {
         city,
         image_url: publicUrl,
         user_id: user.id,
-        status: "pending",
+        status: "approved",
       }
 
       // Inserir o pet e obter o ID

--- a/app/perdidos/cadastrar/form-container-simple.tsx
+++ b/app/perdidos/cadastrar/form-container-simple.tsx
@@ -100,7 +100,7 @@ export default function SimpleFormContainer() {
         city,
         image_url: imageUrl,
         user_id: user.id,
-        status: "pending",
+        status: "approved",
       }
 
       // Inserir o pet e obter o ID

--- a/components/FoundPetForm.tsx
+++ b/components/FoundPetForm.tsx
@@ -81,7 +81,7 @@ const defaultFoundPetData: FoundPetData = {
   good_with_dogs: false,
   is_vaccinated: false,
   is_neutered: false,
-  status: "pending", // Ajustado para "pending"
+  status: "approved",
   state: "",
   city: "",
   category: "found",
@@ -259,7 +259,7 @@ function FoundPetForm({ initialData, isEditing = false }: FoundPetFormProps) {
       const contentToCheck = `${petData.name || ""} ${petData.description || ""} ${petData.found_location || ""} ${petData.current_location || ""}`
       const { blocked, keyword } = await checkForBlockedKeywords(contentToCheck, supabase)
 
-      let finalStatus = "pending" // Status padrão é pending
+      let finalStatus = "approved"
       let finalRejectionReason = null
 
       if (blocked && keyword) {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1006,7 +1006,7 @@ export async function createTestPet(userId: string) {
           location_details: "Rua de Teste, 123",
           contact_email: "teste@exemplo.com",
           main_image_url: "/golden-retriever-park.png",
-          status: "pending",
+          status: "approved",
           category: "lost",
           user_id: userId,
         },


### PR DESCRIPTION
## Summary
- automatically approve pet submissions for adoption, lost or found
- update forms to save pets with `approved` status
- adjust moderation action for found pets
- update test data default status

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ee573c68c832da76ce3c6be933150