### PR TITLE
Fix found pets query

### DIFF
--- a/app/encontrados/EncontradosClientPage.tsx
+++ b/app/encontrados/EncontradosClientPage.tsx
@@ -46,8 +46,9 @@ export default function EncontradosClientPage({
       setLoading(true)
       try {
         let query = supabase
-          .from("pets_found")
+          .from("pets")
           .select("*", { count: "exact" })
+          .eq("category", "found")
           .eq("status", "approved")
 
         // Aplicar filtros


### PR DESCRIPTION
## Summary
- query found pets from the unified `pets` table

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f38182f24832d8539cb5088e1e952