### PR TITLE
Fix supabase query chaining for detail pages

### DIFF
--- a/app/adocao/[slug]/page.tsx
+++ b/app/adocao/[slug]/page.tsx
@@ -45,8 +45,8 @@ export async function generateMetadata({ params }: PetAdoptionDetailPageProps): 
     // Query based on whether it's a UUID or slug
     const { data: pet, error } = await supabase
       .from("pets")
-      .select("*")
       .eq(isUuidValue ? "id" : "slug", slugOrId)
+      .select("*")
       .maybeSingle()
 
     if (error || !pet) {
@@ -116,8 +116,8 @@ export default async function PetAdoptionDetailPage({ params }: PetAdoptionDetai
     // Get pet details using slug or UUID
     const { data: pet, error } = await supabase
       .from("pets")
-      .select("*")
       .eq(isUuidValue ? "id" : "slug", slugOrId)
+      .select("*")
       .maybeSingle()
 
     if (error) {

--- a/app/encontrados/EncontradosClientPage.tsx
+++ b/app/encontrados/EncontradosClientPage.tsx
@@ -47,9 +47,9 @@ export default function EncontradosClientPage({
       try {
         let query = supabase
           .from("pets")
-          .select("*", { count: "exact" })
           .eq("category", "found")
           .eq("status", "approved")
+          .select("*", { count: "exact" })
 
         // Aplicar filtros
         if (filters.species && filters.species !== "all") {

--- a/app/encontrados/[slug]/page.tsx
+++ b/app/encontrados/[slug]/page.tsx
@@ -35,9 +35,9 @@ export async function generateMetadata({ params }: PetFoundDetailPageProps): Pro
     // Query based on whether it's a UUID or slug
     const { data: pet } = await supabase
       .from("pets")
-      .select("*") // Adicionado .select("*")
       .eq("category", "found")
       .eq(isUuidValue ? "id" : "slug", idOrSlug)
+      .select("*")
       .maybeSingle()
 
     if (!pet) {
@@ -100,9 +100,9 @@ export default async function PetFoundDetailPage({ params }: PetFoundDetailPageP
     // Buscar o pet encontrado pelo ID ou slug
     const { data: pet, error } = await supabase
       .from("pets")
-      .select("*") // Adicionado .select("*")
       .eq("category", "found")
       .eq(isUuidValue ? "id" : "slug", idOrSlug)
+      .select("*")
       .maybeSingle()
 
     if (error || !pet) {

--- a/app/perdidos/[slug]/page.tsx
+++ b/app/perdidos/[slug]/page.tsx
@@ -35,9 +35,9 @@ export async function generateMetadata({ params }: PetLostDetailPageProps): Prom
     // Query based on whether it's a UUID or slug
     const { data: pet } = await supabase
       .from("pets")
-      .select("*") // Adicionado .select("*")
       .eq("category", "lost")
       .eq(isUuidValue ? "id" : "slug", slugOrId)
+      .select("*")
       .maybeSingle()
 
     if (!pet) {
@@ -106,9 +106,9 @@ export default async function PetLostDetailPage({ params }: PetLostDetailPagePro
     // Query based on whether it's a UUID or slug
     const { data: pet, error } = await supabase
       .from("pets")
-      .select("*") // Adicionado .select("*")
       .eq("category", "lost")
       .eq(isUUID ? "id" : "slug", params.slug)
+      .select("*")
       .maybeSingle()
 
     if (error) {


### PR DESCRIPTION
## Summary
- fix order of query filters on pet detail pages
- adjust query for encontrados client page

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f36cbf030832daa1a05f51fe81dc9