### PR TITLE
Add pet reports table SQL and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,10 @@ When setting up a new Supabase project, run the SQL files inside the `db` folder
 \`\`\`bash
 supabase db execute ./db/create-events-table.sql
 \`\`\`
+To add the pet reports table, run:
+
+```bash
+supabase db execute ./db/create-pet-reports-table.sql
+```
 
 Ensure the Supabase CLI is linked to your project before running the command.

--- a/db/create-pet-reports-table.sql
+++ b/db/create-pet-reports-table.sql
@@ -1,0 +1,11 @@
+-- Table for user reports on pets
+CREATE TABLE IF NOT EXISTS pet_reports (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  pet_id UUID REFERENCES pets(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  reason TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pet_reports_user_pet
+  ON pet_reports (user_id, pet_id);


### PR DESCRIPTION
## Summary
- add SQL script for `pet_reports` table
- document script usage in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f950c9114832da99ce1894ce74007