### PR TITLE
Add initialPets sync effect to found pets page

### DIFF
--- a/app/encontrados/EncontradosClientPage.tsx
+++ b/app/encontrados/EncontradosClientPage.tsx
@@ -47,6 +47,13 @@ export default function EncontradosClientPage({ initialPets }: EncontradosClient
 
   const petsPerPage = 12
 
+  useEffect(() => {
+    // Atualiza os pets quando initialPets muda (ex: navegação de página no servidor)
+    setPets(initialPets)
+    setFilteredPets(initialPets) // Resetar filteredPets também
+    setCurrentPage(1) // Resetar página ao receber novos initialPets
+  }, [initialPets])
+
   // Debug log dos pets recebidos
   console.log(
     "[EncontradosClientPage] Pets recebidos:",


### PR DESCRIPTION
## Summary
- keep found pets list updated when navigating

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68534e8d243c832d94decf196eee2f12