### PR TITLE
Add PetRecognitionButton wrapper

### DIFF
--- a/app/encontrados/[slug]/page.tsx
+++ b/app/encontrados/[slug]/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next"
 import { createClient } from "@/lib/supabase/server"
 import PetDetails from "@/components/PetDetails"
 import { ShareButton } from "@/components/share-button"
-import { PetRecognitionModal } from "@/components/pet-recognition-modal"
+import { PetRecognitionButton } from "@/components/pet-recognition-button"
 import { ReportPetButton } from "@/components/report-pet-button"
 import { isUuid } from "@/lib/slug-utils"
 
@@ -127,7 +127,7 @@ export default async function PetEncontradoPage({ params }: Props) {
                   className="flex-1 min-w-[200px]"
                 />
 
-                <PetRecognitionModal
+                <PetRecognitionButton
                   petId={pet.id}
                   petName={pet.name || "Pet encontrado"}
                   className="flex-1 min-w-[200px]"

--- a/components/pet-recognition-button.tsx
+++ b/components/pet-recognition-button.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Eye } from "lucide-react"
+import { PetRecognitionModal } from "./pet-recognition-modal"
+
+interface PetRecognitionButtonProps {
+  petId: string
+  petName: string
+  className?: string
+}
+
+export function PetRecognitionButton({ petId, petName, className }: PetRecognitionButtonProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)} className={className}>
+        <Eye className="h-4 w-4 mr-2" />
+        Reconhecer
+      </Button>
+
+      <PetRecognitionModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        petId={petId}
+        petName={petName}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add `PetRecognitionButton` to open `PetRecognitionModal`
- use new button component in `encontrados/[slug]` page

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68534ff2ae6c832d813560ce7554156a