### PR TITLE
Fix found pet edit query

### DIFF
--- a/app/encontrados/edit/[id]/page.tsx
+++ b/app/encontrados/edit/[id]/page.tsx
@@ -16,8 +16,12 @@ export default async function EditFoundPetPage({ params }: { params: { id: strin
     redirect("/login?redirect=/encontrados/edit/" + params.id)
   }
 
-  // Buscar os dados do pet encontrado
-  const { data: pet, error } = await supabase.from("pets_found").select("*").eq("id", params.id).single()
+  // Buscar os dados do pet encontrado na tabela unificada
+  const { data: pet, error } = await supabase
+    .from("pets")
+    .select("*")
+    .eq("id", params.id)
+    .single()
 
   if (error || !pet) {
     console.error("Erro ao buscar pet encontrado:", error)


### PR DESCRIPTION
## Summary
- update found pet edit page to read from `pets` table

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853511592cc832dbb96a9e6eac9e701