### PR TITLE
fix: ignore invalid slugs in PetCard

### DIFF
--- a/components/PetCard.tsx
+++ b/components/PetCard.tsx
@@ -61,7 +61,8 @@ function PetCard({
 
   // Função para gerar a URL de detalhes
   const getDetailUrl = () => {
-    const identifier = slug || id
+    const validSlug = slug && !["{}", "%7B%7D", "undefined", "null"].includes(slug)
+    const identifier = validSlug ? slug : id
     console.log(`[PetCard] Gerando URL para pet ${id}, slug: ${slug}, type: ${type}, identifier: ${identifier}`)
 
     switch (type) {

--- a/components/pet-card.tsx
+++ b/components/pet-card.tsx
@@ -145,7 +145,10 @@ export default function PetCard({
       found: "/encontrados/",
     }[type]
 
-    return `${baseUrl}${slug || id}`
+    const validSlug = slug && !["{}", "%7B%7D", "undefined", "null"].includes(slug)
+    const identifier = validSlug ? slug : id
+
+    return `${baseUrl}${identifier}`
   }
 
   // Determinar a URL de edição com base no tipo de pet


### PR DESCRIPTION
## Summary
- improve slug validation in PetCard
- update lowercase pet-card to use new slug validation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685356c97308832da5ebd3503006f8ba