### PR TITLE
Fix owner actions visibility on pet pages

### DIFF
--- a/app/adocao/[slug]/page.tsx
+++ b/app/adocao/[slug]/page.tsx
@@ -124,13 +124,19 @@ export default async function PetAdocaoPage({ params }: Props) {
     notFound()
   }
 
+  const supabase = createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  const isOwner = session?.user?.id === pet.user_id
+
   const location = pet.city && pet.state ? `${pet.city}, ${pet.state}` : pet.city || pet.state || ""
 
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto py-8 px-4">
         <div className="max-w-6xl mx-auto">
-          <PetDetails pet={pet} type="adoption" />
+          <PetDetails pet={pet} type="adoption" isOwner={isOwner} />
 
           <div className="mt-8 space-y-6">
             <div className="bg-card rounded-lg p-6 border">

--- a/app/encontrados/[slug]/page.tsx
+++ b/app/encontrados/[slug]/page.tsx
@@ -104,13 +104,19 @@ export default async function PetEncontradoPage({ params }: Props) {
     notFound()
   }
 
+  const supabase = createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  const isOwner = session?.user?.id === pet.user_id
+
   const location = pet.city && pet.state ? `${pet.city}, ${pet.state}` : pet.city || pet.state || ""
 
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto py-8 px-4">
         <div className="max-w-6xl mx-auto">
-          <PetDetails pet={pet} type="found" />
+          <PetDetails pet={pet} type="found" isOwner={isOwner} />
 
           <div className="mt-8 space-y-6">
             <div className="bg-card rounded-lg p-6 border">

--- a/app/perdidos/[slug]/page.tsx
+++ b/app/perdidos/[slug]/page.tsx
@@ -111,13 +111,19 @@ export default async function PetPerdidoPage({ params }: Props) {
     notFound()
   }
 
+  const supabase = createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  const isOwner = session?.user?.id === pet.user_id
+
   const location = pet.city && pet.state ? `${pet.city}, ${pet.state}` : pet.city || pet.state || ""
 
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto py-8 px-4">
         <div className="max-w-6xl mx-auto">
-          <PetDetails pet={pet} type="lost" />
+          <PetDetails pet={pet} type="lost" isOwner={isOwner} />
 
           <div className="mt-8 space-y-6">
             <div className="bg-card rounded-lg p-6 border">


### PR DESCRIPTION
## Summary
- ensure logged-in owners see resolve/delete actions in lost, found, and adoption pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685371a04104832d9c3afd1edf840774