### PR TITLE
Handle unauthenticated state on delete pages

### DIFF
--- a/app/dashboard/pets/[type]/[id]/delete/page.tsx
+++ b/app/dashboard/pets/[type]/[id]/delete/page.tsx
@@ -31,9 +31,19 @@ function DeletePetContent({ params }: { params: { type: string; id: string } }) 
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>
     const fetchPet = async () => {
-      if (!user?.id) return
+      if (!user?.id) {
+        timeout = setTimeout(() => {
+          if (!user?.id) {
+            setError("Não autenticado")
+            setIsLoading(false)
+          }
+        }, 1000)
+        return
+      }
 
+      setError(null)
       setIsLoading(true)
       try {
         let petData = null
@@ -78,6 +88,7 @@ function DeletePetContent({ params }: { params: { type: string; id: string } }) 
     }
 
     fetchPet()
+    return () => clearTimeout(timeout)
   }, [params.id, params.type, user?.id])
 
   const handleDelete = async () => {

--- a/app/dashboard/pets/adoption/[id]/delete/page.tsx
+++ b/app/dashboard/pets/adoption/[id]/delete/page.tsx
@@ -31,9 +31,19 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>
     const fetchPet = async () => {
-      if (!user?.id) return
+      if (!user?.id) {
+        timeout = setTimeout(() => {
+          if (!user?.id) {
+            setError("Não autenticado")
+            setIsLoading(false)
+          }
+        }, 1000)
+        return
+      }
 
+      setError(null)
       setIsLoading(true)
       try {
         const petData = await getPetById(id)
@@ -59,6 +69,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
     }
 
     fetchPet()
+    return () => clearTimeout(timeout)
   }, [id, type, user?.id])
 
   const handleDelete = async () => {

--- a/app/dashboard/pets/found/[id]/delete/page.tsx
+++ b/app/dashboard/pets/found/[id]/delete/page.tsx
@@ -31,9 +31,19 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>
     const fetchPet = async () => {
-      if (!user?.id) return
+      if (!user?.id) {
+        timeout = setTimeout(() => {
+          if (!user?.id) {
+            setError("Não autenticado")
+            setIsLoading(false)
+          }
+        }, 1000)
+        return
+      }
 
+      setError(null)
       setIsLoading(true)
       try {
         const petData = await getFoundPetById(id)
@@ -59,6 +69,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
     }
 
     fetchPet()
+    return () => clearTimeout(timeout)
   }, [id, type, user?.id])
 
   const handleDelete = async () => {

--- a/app/dashboard/pets/lost/[id]/delete/page.tsx
+++ b/app/dashboard/pets/lost/[id]/delete/page.tsx
@@ -31,9 +31,19 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>
     const fetchPet = async () => {
-      if (!user?.id) return
+      if (!user?.id) {
+        timeout = setTimeout(() => {
+          if (!user?.id) {
+            setError("Não autenticado")
+            setIsLoading(false)
+          }
+        }, 1000)
+        return
+      }
 
+      setError(null)
       setIsLoading(true)
       try {
         const petData = await getLostPetById(id)
@@ -59,6 +69,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
     }
 
     fetchPet()
+    return () => clearTimeout(timeout)
   }, [id, type, user?.id])
 
   const handleDelete = async () => {


### PR DESCRIPTION
## Summary
- display an authentication error if the user does not load
- clear loading flag when unauthenticated

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856f48597a8832db83efb1b6a78c748