### PR TITLE
Add ONG registration link

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -230,6 +230,12 @@ export default function LoginPage() {
               Cadastre-se
             </Link>
           </div>
+          <div className="text-sm text-center">
+            É uma ONG?{" "}
+            <Link href="/ongs/register" className="text-primary hover:underline">
+              Cadastre sua organização
+            </Link>
+          </div>
         </CardFooter>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- add a link for NGOs to register right below the existing signup link on the login page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685702796904832dae524e577fc17be0