### PR TITLE
Fix ONG slug creation order

### DIFF
--- a/app/actions/auth-actions.ts
+++ b/app/actions/auth-actions.ts
@@ -89,7 +89,11 @@ export async function registerUserAndNgoAction(
   if (isNgo) {
     const ngoData = validation.data // This will be the merged schema with NGO fields
     try {
-      const baseSlug = await generateEntitySlug(ngoData.ngoName, "ong", ngoData.ngoCity, undefined)
+      const baseSlug = await generateEntitySlug(
+        "ong",
+        { name: ngoData.ngoName, city: ngoData.ngoCity, state: ngoData.ngoState },
+        undefined,
+      )
       const uniqueSlug = await generateUniqueSlug(baseSlug, "ongs", undefined) // Pass undefined for new ONG ID
 
       const { data: ong, error: ongInsertError } = await supabase


### PR DESCRIPTION
## Summary
- correct argument order for `generateEntitySlug` when registering an ONG

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68572a6098bc832db8bdc06066375fc5