### PR TITLE
Add dynamic export for ONG pets page

### DIFF
--- a/app/ongs/dashboard/pets/cadastrar/page.tsx
+++ b/app/ongs/dashboard/pets/cadastrar/page.tsx
@@ -3,6 +3,8 @@ import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 import CadastrarPetClient from "./client"
 
+export const dynamic = "force-dynamic"
+
 export default async function CadastrarPetPage() {
   const supabase = createServerComponentClient({ cookies })
 


### PR DESCRIPTION
## Summary
- ensure `/ongs/dashboard/pets/cadastrar` is always rendered dynamically

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68599d3fdbb4832d8e4aea51235db4de