### PR TITLE
Initialize Supabase session on adoption registration route

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,7 +9,10 @@ const SPECIAL_ROUTES = ["/cadastrar", "/editar", "/excluir", "/novo"]
 export async function middleware(request: NextRequest) {
   // Ignorar a rota de cadastro de pets para adoção
   if (request.nextUrl.pathname === "/cadastrar-pet-adocao") {
-    return NextResponse.next()
+    const response = NextResponse.next()
+    const supabase = createMiddlewareClient({ req: request, res: response })
+    await supabase.auth.getSession()
+    return response
   }
 
   // Permitir redirecionamento para rotas especiais


### PR DESCRIPTION
## Summary
- ensure Supabase middleware client initializes for `/cadastrar-pet-adocao`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859a8a3d9f4832d8f43fafe3f56f5e4