### PR TITLE
Use mappers in admin and dashboard

### DIFF
--- a/app/admin/moderation/page.tsx
+++ b/app/admin/moderation/page.tsx
@@ -9,6 +9,7 @@ import Image from "next/image"
 import { ModerationActions } from "@/components/moderation-actions"
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
 import AdminAuthCheck from "@/components/admin-auth-check"
+import { mapPetSpecies } from "@/lib/utils"
 
 // Tipos
 type Pet = {
@@ -294,7 +295,7 @@ export default function AdminModerationPage() {
                           <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mt-4">
                             <div>
                               <p className="text-sm font-medium">Espécie:</p>
-                              <p className="text-sm">{pet.species}</p>
+                              <p className="text-sm">{mapPetSpecies(pet.species)}</p>
                             </div>
                             <div>
                               <p className="text-sm font-medium">Raça:</p>

--- a/app/admin/ongs/[id]/page.tsx
+++ b/app/admin/ongs/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { MapPinIcon, MailIcon, PhoneIcon, ClockIcon, ArrowLeftIcon, PawPrintIcon } from "lucide-react"
+import { mapPetSpecies } from "@/lib/utils"
 
 export default async function OngDetailPage({ params }: { params: { id: string } }) {
   const supabase = createServerComponentClient({ cookies })
@@ -154,7 +155,7 @@ export default async function OngDetailPage({ params }: { params: { id: string }
                           <div>
                             <h4 className="font-medium">{pet.name}</h4>
                             <p className="text-sm text-muted-foreground">
-                              {pet.species} {pet.breed && `• ${pet.breed}`}
+                              {mapPetSpecies(pet.species)} {pet.breed && `• ${pet.breed}`}
                             </p>
                             <Badge
                               variant="outline"

--- a/app/admin/pets/[id]/delete/page.tsx
+++ b/app/admin/pets/[id]/delete/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { DeletePetForm } from "./delete-pet-form"
 import Image from "next/image"
+import { mapPetSpecies } from "@/lib/utils"
 
 export const metadata: Metadata = {
   title: "Excluir Pet | Admin PetAdot",
@@ -74,7 +75,7 @@ export default async function DeletePetPage({ params }: { params: { id: string }
               <div className="flex-1">
                 <h3 className="font-medium">{pet.name || "Sem nome"}</h3>
                 <p className="text-sm text-muted-foreground">
-                  {pet.species} {pet.breed && `• ${pet.breed}`}
+                  {mapPetSpecies(pet.species)} {pet.breed && `• ${pet.breed}`}
                 </p>
                 <p className="text-sm text-muted-foreground">
                   {pet.city}, {pet.state}

--- a/app/admin/pets/[id]/page.tsx
+++ b/app/admin/pets/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { mapPetSpecies, mapPetSize, mapPetGender, mapPetColor } from "@/lib/utils"
+import { mapPetSpecies, mapPetSize, mapPetGender, mapPetColor, mapPetAge } from "@/lib/utils"
 
 const PetDetailPage = async ({ params }: { params: { id: string } }) => {
   const { id } = params
@@ -21,25 +21,25 @@ const PetDetailPage = async ({ params }: { params: { id: string } }) => {
   }
 
   if (!pet) {
-    return <div>Pet not found</div>
+    return <div>Pet não encontrado</div>
   }
 
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Pet Details</h1>
+      <h1 className="text-2xl font-bold mb-4">Detalhes do Pet</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <img src={pet.images[0] || "/placeholder.svg"} alt={pet.name} className="rounded-lg shadow-md" />
         </div>
         <div>
           <h2 className="text-xl font-semibold">{pet.name}</h2>
-          <p>Species: {mapPetSpecies(pet.species)}</p>
-          <p>Size: {mapPetSize(pet.size)}</p>
-          <p>Gender: {mapPetGender(pet.gender)}</p>
-          <p>Color: {mapPetColor(pet.color)}</p>
-          <p>Breed: {pet.breed}</p>
-          <p>Age: {pet.age}</p>
-          <p>Description: {pet.description}</p>
+          <p>Espécie: {mapPetSpecies(pet.species)}</p>
+          <p>Porte: {mapPetSize(pet.size)}</p>
+          <p>Sexo: {mapPetGender(pet.gender)}</p>
+          <p>Cor: {mapPetColor(pet.color)}</p>
+          <p>Raça: {pet.breed}</p>
+          <p>Idade: {mapPetAge(pet.age)}</p>
+          <p>Descrição: {pet.description}</p>
           {/* Add more details as needed */}
         </div>
       </div>

--- a/app/admin/pets/pet-detail.tsx
+++ b/app/admin/pets/pet-detail.tsx
@@ -12,6 +12,13 @@ import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
 import { PetStatusButton } from "@/components/pet-status-button"
 import { PetResolvedAlert } from "@/components/pet-resolved-alert"
 import { Loader2, AlertCircle, ArrowLeft, Edit, Trash2 } from "lucide-react"
+import {
+  mapPetAge,
+  mapPetColor,
+  mapPetGender,
+  mapPetSize,
+  mapPetSpecies,
+} from "@/lib/utils"
 
 interface PetDetailProps {
   petId: string
@@ -225,7 +232,7 @@ export function PetDetail({ petId, petType }: PetDetailProps) {
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                       <h3 className="text-sm font-medium text-muted-foreground mb-1">Espécie</h3>
-                      <p>{pet.species || "Não informado"}</p>
+                      <p>{mapPetSpecies(pet.species)}</p>
                     </div>
                     <div>
                       <h3 className="text-sm font-medium text-muted-foreground mb-1">Raça</h3>
@@ -233,19 +240,19 @@ export function PetDetail({ petId, petType }: PetDetailProps) {
                     </div>
                     <div>
                       <h3 className="text-sm font-medium text-muted-foreground mb-1">Idade</h3>
-                      <p>{pet.age || "Não informado"}</p>
+                      <p>{mapPetAge(pet.age)}</p>
                     </div>
                     <div>
                       <h3 className="text-sm font-medium text-muted-foreground mb-1">Porte</h3>
-                      <p>{pet.size || "Não informado"}</p>
+                      <p>{mapPetSize(pet.size)}</p>
                     </div>
                     <div>
                       <h3 className="text-sm font-medium text-muted-foreground mb-1">Sexo</h3>
-                      <p>{pet.gender || "Não informado"}</p>
+                      <p>{mapPetGender(pet.gender)}</p>
                     </div>
                     <div>
                       <h3 className="text-sm font-medium text-muted-foreground mb-1">Cor</h3>
-                      <p>{pet.color || "Não informado"}</p>
+                      <p>{mapPetColor(pet.color)}</p>
                     </div>
                   </div>
 

--- a/app/admin/pets/pets-table.tsx
+++ b/app/admin/pets/pets-table.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input"
 import { Search, Eye, Edit, Trash2 } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
+import { mapPetSpecies } from "@/lib/utils"
 
 type Pet = {
   id: string
@@ -112,7 +113,7 @@ export function PetsTable() {
             <div>
               <h3 className="font-medium truncate">{pet.name || "Sem nome"}</h3>
               <p className="text-sm text-muted-foreground">
-                {pet.species} {pet.breed && `• ${pet.breed}`}
+                {mapPetSpecies(pet.species)} {pet.breed && `• ${pet.breed}`}
               </p>
               <p className="text-sm text-muted-foreground">
                 {pet.city}, {pet.state}

--- a/app/dashboard/pets/[type]/[id]/delete/page.tsx
+++ b/app/dashboard/pets/[type]/[id]/delete/page.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { useToast } from "@/components/ui/use-toast"
 import { getPetById, getLostPetById, getFoundPetById, deleteUserPet } from "@/lib/supabase"
 import { ArrowLeft, AlertTriangle, Loader2 } from "lucide-react"
+import { mapPetAge, mapPetSize } from "@/lib/utils"
 
 export default function DeletePetPage({ params }: { params: { type: string; id: string } }) {
   return (
@@ -231,15 +232,7 @@ function DeletePetContent({ params }: { params: { type: string; id: string } }) 
             <h2 className="text-xl font-semibold">{pet.name || "Pet sem nome"}</h2>
             <p className="text-muted-foreground mt-1">
               {pet.type === "adoption"
-                ? `${pet.age || "Idade não informada"} • ${
-                    pet.size === "small"
-                      ? "Pequeno"
-                      : pet.size === "medium"
-                        ? "Médio"
-                        : pet.size === "large"
-                          ? "Grande"
-                          : pet.size
-                  }`
+                ? `${mapPetAge(pet.age)} • ${mapPetSize(pet.size)}`
                 : pet.type === "lost"
                   ? `Perdido em ${pet.last_seen_location}`
                   : `Encontrado em ${pet.found_location}`}

--- a/app/dashboard/pets/[type]/[id]/page.tsx
+++ b/app/dashboard/pets/[type]/[id]/page.tsx
@@ -1,4 +1,9 @@
-import { mapPetSpecies, mapPetSize, mapPetGender, mapPetColor } from "@/lib/utils"
+import {
+  mapPetSpecies,
+  mapPetSize,
+  mapPetGender,
+  mapPetColor,
+} from "@/lib/utils"
 
 export default async function PetDetailPage({ params }: { params: { type: string; id: string } }) {
   const { type, id } = params
@@ -18,7 +23,7 @@ export default async function PetDetailPage({ params }: { params: { type: string
 
   return (
     <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Pet Details</h1>
+      <h1 className="text-2xl font-bold mb-4">Detalhes do Pet</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <img src={pet.imageUrl || "/placeholder.svg"} alt={pet.name} className="rounded-lg shadow-md" />
@@ -26,22 +31,22 @@ export default async function PetDetailPage({ params }: { params: { type: string
         <div>
           <h2 className="text-xl font-semibold">{pet.name}</h2>
           <p>
-            <strong>Type:</strong> {pet.type}
+            <strong>Tipo:</strong> {pet.type}
           </p>
           <p>
-            <strong>Species:</strong> {mapPetSpecies(pet.species)}
+            <strong>Espécie:</strong> {mapPetSpecies(pet.species)}
           </p>
           <p>
-            <strong>Size:</strong> {mapPetSize(pet.size)}
+            <strong>Porte:</strong> {mapPetSize(pet.size)}
           </p>
           <p>
-            <strong>Gender:</strong> {mapPetGender(pet.gender)}
+            <strong>Sexo:</strong> {mapPetGender(pet.gender)}
           </p>
           <p>
-            <strong>Color:</strong> {mapPetColor(pet.color)}
+            <strong>Cor:</strong> {mapPetColor(pet.color)}
           </p>
           <p>
-            <strong>Description:</strong> {pet.description}
+            <strong>Descrição:</strong> {pet.description}
           </p>
         </div>
       </div>

--- a/app/dashboard/pets/adoption/[id]/delete/page.tsx
+++ b/app/dashboard/pets/adoption/[id]/delete/page.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { useToast } from "@/components/ui/use-toast"
 import { getPetById, deleteUserPet } from "@/lib/supabase"
 import { ArrowLeft, AlertTriangle, Loader2 } from "lucide-react"
+import { mapPetAge, mapPetSize } from "@/lib/utils"
 
 export default function DeleteAdoptionPetPage({ params }: { params: { id: string } }) {
   return (
@@ -164,7 +165,7 @@ function DeletePetContent({ id, type }: { id: string; type: string }) {
             </div>
             <h2 className="text-xl font-semibold">{pet.name || "Pet sem nome"}</h2>
             <p className="text-muted-foreground mt-1">
-              {pet.age || "Idade não informada"} • {pet.size || "Porte não informado"}
+              {mapPetAge(pet.age)} • {mapPetSize(pet.size)}
             </p>
           </CardContent>
           <CardFooter className="flex justify-between">

--- a/app/dashboard/pets/lost/[id]/page.tsx
+++ b/app/dashboard/pets/lost/[id]/page.tsx
@@ -13,6 +13,13 @@ import { useToast } from "@/components/ui/use-toast"
 import { getLostPetById, deleteUserPet } from "@/lib/supabase"
 import { ArrowLeft, Pencil, Trash2, Loader2 } from "lucide-react"
 import { format } from "date-fns"
+import {
+  mapPetAge,
+  mapPetColor,
+  mapPetGender,
+  mapPetSize,
+  mapPetSpecies,
+} from "@/lib/utils"
 import { ptBR } from "date-fns/locale"
 
 export default function LostPetDetailsPage({ params }: { params: { id: string } }) {
@@ -176,7 +183,7 @@ function LostPetDetails({ id }: { id: string }) {
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
                 <div>
                   <p className="text-sm text-muted-foreground">Espécie</p>
-                  <p className="font-medium">{pet.species || "Não informado"}</p>
+                  <p className="font-medium">{mapPetSpecies(pet.species)}</p>
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Raça</p>
@@ -184,25 +191,19 @@ function LostPetDetails({ id }: { id: string }) {
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Idade</p>
-                  <p className="font-medium">{pet.age || "Não informado"}</p>
+                  <p className="font-medium">{mapPetAge(pet.age)}</p>
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Porte</p>
-                  <p className="font-medium">{pet.size || "Não informado"}</p>
+                  <p className="font-medium">{mapPetSize(pet.size)}</p>
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Sexo</p>
-                  <p className="font-medium">
-                    {pet.gender === "male"
-                      ? "Macho"
-                      : pet.gender === "female"
-                        ? "Fêmea"
-                        : pet.gender || "Não informado"}
-                  </p>
+                  <p className="font-medium">{mapPetGender(pet.gender)}</p>
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">Cor</p>
-                  <p className="font-medium">{pet.color || "Não informado"}</p>
+                  <p className="font-medium">{mapPetColor(pet.color)}</p>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- display pet fields in Portuguese using mapping helpers
- translate placeholder admin and dashboard pages
- map species in admin moderation and ONG pages

## Testing
- `pnpm lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685a970286cc832d85a7411e5217be13