### PR TITLE
Fix server actions to use createServerActionClient

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,16 +1,15 @@
 "use server"
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 
 // Import the slug utilities
 import { generateEntitySlug, generateUniqueSlug } from "@/lib/slug-utils"
 
 // Função para garantir que o usuário existe na tabela users
 export async function ensureUserExists(userId: string, userData: any) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   // Verificar se o usuário já existe
   const { data: existingUser, error: checkError } = await supabase.from("users").select("*").eq("id", userId).single()
@@ -41,7 +40,7 @@ export async function ensureUserExists(userId: string, userData: any) {
 // Função para verificar conteúdo contra palavras-chave bloqueadas
 async function checkContentForBlockedKeywords(
   content: string,
-  supabaseClient: ReturnType<typeof createServerComponentClient>,
+  supabaseClient: ReturnType<typeof createServerActionClient>,
 ): Promise<{ blocked: boolean; keyword?: string }> {
   try {
     console.log("Verificando conteúdo para palavras-chave bloqueadas:", content)
@@ -107,7 +106,7 @@ async function checkContentForBlockedKeywords(
 
 // Função para criar uma ONG
 export async function createOng(ongData: any) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Obter a sessão do usuário
@@ -172,7 +171,7 @@ export async function createOng(ongData: any) {
 
 // Função para atualizar uma ONG
 export async function updateOng(ongId: string, ongData: any) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Obter a sessão do usuário
@@ -236,7 +235,7 @@ export async function updateOng(ongId: string, ongData: any) {
 
 // Função para cadastrar um pet para adoção
 export async function createAdoptionPet(petData: any) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     console.log("Iniciando cadastro de pet para adoção:", petData)
@@ -344,7 +343,7 @@ export async function createAdoptionPet(petData: any) {
 
 // Função para criar um pet perdido
 export async function createLostPet(petData: any) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     console.log("Iniciando cadastro de pet perdido")
@@ -439,7 +438,7 @@ export async function createLostPet(petData: any) {
 
 // Função para criar um pet encontrado
 export async function createFoundPet(petData: any) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     console.log("Iniciando cadastro de pet encontrado:", petData)
@@ -548,7 +547,7 @@ export type EventFormData = {
 
 // Função para criar um evento
 export async function createEvent(eventData: EventFormData) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     console.log("Iniciando cadastro de evento:", eventData)
@@ -647,7 +646,7 @@ export async function createEvent(eventData: EventFormData) {
 
 // Função para verificar uma ONG
 export async function verifyOng(ongId: string) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se o usuário é um administrador
@@ -692,7 +691,7 @@ export async function verifyOng(ongId: string) {
 
 // Função para excluir uma ONG
 export async function deleteOng(ongId: string) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se o usuário é um administrador
@@ -759,7 +758,7 @@ export async function deleteOng(ongId: string) {
 
 // Função para excluir um evento (admin)
 export async function deleteEventAdmin(eventId: string) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se o usuário é um administrador
@@ -805,7 +804,7 @@ export async function deleteEventAdmin(eventId: string) {
 
 // Update the approveItem function
 export async function approveItem(itemId: string, type: "adoption" | "event" | "lost" | "found") {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se o usuário é um administrador
@@ -874,7 +873,7 @@ export async function approveItem(itemId: string, type: "adoption" | "event" | "
 
 // Update the rejectItem function
 export async function rejectItem(itemId: string, type: "adoption" | "event" | "lost" | "found") {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se o usuário é um administrador

--- a/app/actions/admin-actions.ts
+++ b/app/actions/admin-actions.ts
@@ -1,12 +1,12 @@
 "use server"
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
 
 // Função para verificar se um usuário existe na autenticação
 export async function checkUserExists(email: string) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se o usuário que está fazendo a requisição é um administrador
@@ -63,7 +63,7 @@ export async function checkUserExists(email: string) {
 
 // Função para promover um usuário existente para administrador
 export async function promoteToAdmin(userId: string) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se o usuário que está fazendo a requisição é um administrador
@@ -105,7 +105,7 @@ export async function promoteToAdmin(userId: string) {
 
 // Função para criar um novo usuário administrador
 export async function createAdminUser(email: string, password: string, name: string) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se o usuário que está fazendo a requisição é um administrador

--- a/app/actions/admin-user-actions.ts
+++ b/app/actions/admin-user-actions.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
 
@@ -16,7 +16,7 @@ export async function createOrPromoteAdmin(
   password: string,
   name: string,
 ): Promise<AdminCreationResult> {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
   console.log(`Tentando criar/promover admin para: ${email}`)
 
   try {
@@ -282,7 +282,7 @@ export async function verifyAndFixAdminStatus(userId: string): Promise<{
   message: string
   isAdmin: boolean
 }> {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se o usuário existe na tabela users

--- a/app/actions/found-pet-actions.ts
+++ b/app/actions/found-pet-actions.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
 import { generateEntitySlug } from "@/lib/slug-utils"
@@ -8,7 +8,7 @@ import { generateEntitySlug } from "@/lib/slug-utils"
 // Função para verificar conteúdo contra palavras-chave bloqueadas
 async function checkContentForBlockedKeywords(
   content: string,
-  supabaseClient: ReturnType<typeof createServerComponentClient>,
+  supabaseClient: ReturnType<typeof createServerActionClient>,
 ): Promise<{ blocked: boolean; keyword?: string }> {
   try {
     console.log("Verificando conteúdo para palavras-chave bloqueadas:", content)
@@ -73,7 +73,7 @@ async function checkContentForBlockedKeywords(
 }
 
 export async function createFoundPet(formData: FormData) {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     console.log("Iniciando cadastro de pet encontrado")

--- a/app/actions/partner-actions.ts
+++ b/app/actions/partner-actions.ts
@@ -1,13 +1,13 @@
 "use server"
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
 import { generateEntitySlug, generateUniqueSlug } from "@/lib/slug-utils"
 
 // Verificar se o usuário é administrador
 async function isAdmin() {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   const {
     data: { session },
@@ -32,7 +32,7 @@ export async function createPartner(formData: FormData) {
     return { success: false, error: "Não autorizado" }
   }
 
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     const name = formData.get("name") as string
@@ -101,7 +101,7 @@ export async function updatePartner(id: string, formData: FormData) {
     return { success: false, error: "Não autorizado" }
   }
 
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     const name = formData.get("name") as string
@@ -176,7 +176,7 @@ export async function deletePartner(id: string) {
     return { success: false, error: "Não autorizado" }
   }
 
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Excluir parceiro

--- a/app/actions/pet-status.ts
+++ b/app/actions/pet-status.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
 
@@ -13,7 +13,7 @@ export async function updatePetStatus(
   status: ResolutionStatus,
   notes?: string,
 ): Promise<{ success: boolean; error?: string }> {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     console.log("updatePetStatus chamada com:", { petId, petType, status, notes })

--- a/app/actions/pet-stories-actions.ts
+++ b/app/actions/pet-stories-actions.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { revalidatePath } from "next/cache"
 
@@ -73,7 +73,7 @@ async function createPetStoriesTable(supabase) {
 // Criar uma nova história
 export async function createPetStory(formData: FormData) {
   try {
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {
@@ -148,7 +148,7 @@ export async function createPetStory(formData: FormData) {
 // Obter todas as histórias (aprovadas para usuários não autenticados, todas para admin)
 export async function getPetStories(page = 1, limit = 10) {
   try {
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {
@@ -259,7 +259,7 @@ export async function getPetStoryById(id: string) {
     console.log("Buscando história com ID:", id)
 
     // Usar o cliente do servidor para autenticação
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {
@@ -333,7 +333,7 @@ export async function getPetStoryById(id: string) {
 // Atualizar uma história
 export async function updatePetStory(storyId: string, formData: FormData) {
   try {
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {
@@ -438,7 +438,7 @@ export async function deletePetStory(id: string) {
     console.log("Tentando excluir história com ID:", id)
 
     // Usar o cliente do servidor para autenticação
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {
@@ -531,7 +531,7 @@ export async function deletePetStory(id: string) {
 // Aprovar uma história (apenas admin)
 export async function approvePetStory(id: string) {
   try {
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {
@@ -598,7 +598,7 @@ export async function approvePetStory(id: string) {
 // Rejeitar uma história (apenas admin)
 export async function rejectPetStory(id: string) {
   try {
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {
@@ -645,7 +645,7 @@ export async function rejectPetStory(id: string) {
 // Curtir uma história
 export async function likeStory(id: string) {
   try {
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {
@@ -696,7 +696,7 @@ export async function likeStory(id: string) {
 // Obter histórias pendentes (apenas admin)
 export async function getPendingPetStories() {
   try {
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {
@@ -787,7 +787,7 @@ export async function getPendingPetStories() {
 // Obter histórias do usuário atual
 export async function getUserPetStories() {
   try {
-    const supabase = createServerComponentClient({ cookies })
+    const supabase = createServerActionClient({ cookies })
 
     // Verificar se o usuário está autenticado
     const {

--- a/app/actions/test-data-actions.ts
+++ b/app/actions/test-data-actions.ts
@@ -1,11 +1,11 @@
 "use server"
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { v4 as uuidv4 } from "uuid"
 
 export async function createTestPets() {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   try {
     // Verificar se já existem pets

--- a/lib/slug-utils.ts
+++ b/lib/slug-utils.ts
@@ -2,7 +2,7 @@
  * Utilitários para geração e manipulação de slugs
  */
 
-import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
+import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 
 /**
@@ -212,7 +212,7 @@ export function generateSlug(text: string): string {
  * @returns Verdadeiro se o slug já existir
  */
 export async function slugExists(slug: string, table: string, excludeId?: string): Promise<boolean> {
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerActionClient({ cookies })
 
   let query = supabase.from(table).select("id").eq("slug", slug)
 


### PR DESCRIPTION
## Summary
- switch remaining server actions to `createServerActionClient`
- update slug utilities to use `createServerActionClient`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685aa262853c832da94657f11de44e1f