### PR TITLE
Fix default exports for pet forms

### DIFF
--- a/components/FoundPetForm.tsx
+++ b/components/FoundPetForm.tsx
@@ -41,7 +41,7 @@ function SubmitButton() {
   )
 }
 
-export function FoundPetForm({ action, userId }: FoundPetFormProps) {
+export default function FoundPetForm({ action, userId }: FoundPetFormProps) {
   const [imageUrl, setImageUrl] = useState("")
   const [isSpecialNeeds, setIsSpecialNeeds] = useState(false)
   const [species, setSpecies] = useState("dog")
@@ -287,4 +287,4 @@ export function FoundPetForm({ action, userId }: FoundPetFormProps) {
   )
 }
 
-export default FoundPetForm
+export { FoundPetForm }

--- a/components/LostPetForm.tsx
+++ b/components/LostPetForm.tsx
@@ -26,7 +26,7 @@ function SubmitButton() {
   )
 }
 
-export function LostPetForm({ action, userId }: LostPetFormProps) {
+export default function LostPetForm({ action, userId }: LostPetFormProps) {
   const [imageUrl, setImageUrl] = useState("")
   const [isSpecialNeeds, setIsSpecialNeeds] = useState(false)
   const [species, setSpecies] = useState("dog")
@@ -259,4 +259,4 @@ export function LostPetForm({ action, userId }: LostPetFormProps) {
   )
 }
 
-export default LostPetForm
+export { LostPetForm }


### PR DESCRIPTION
## Summary
- ensure FoundPetForm and LostPetForm expose default exports at the function declaration
- keep named exports so existing imports continue working

## Testing
- `pnpm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68688be508dc832d8a89068f16fa8f8b