### PR TITLE
Update forms to include location fields

### DIFF
--- a/components/AdoptionPetForm.tsx
+++ b/components/AdoptionPetForm.tsx
@@ -32,6 +32,8 @@ export function AdoptionPetForm({ action, ongId }: AdoptionPetFormProps) {
   const [gender, setGender] = useState("Macho")
   const [size, setSize] = useState("Pequeno")
   const [color, setColor] = useState("Preto")
+  const [state, setState] = useState("")
+  const [city, setCity] = useState("")
 
   return (
     <form action={action} className="space-y-6 max-w-2xl mx-auto">
@@ -157,7 +159,13 @@ export function AdoptionPetForm({ action, ongId }: AdoptionPetFormProps) {
           </div>
         </div>
 
-        <SimpleLocationSelector onStateChange={() => {}} onCityChange={() => {}} required={true} />
+        <SimpleLocationSelector
+          onStateChange={setState}
+          onCityChange={setCity}
+          required={true}
+        />
+        <input type="hidden" name="state" value={state} />
+        <input type="hidden" name="city" value={city} />
 
         <div>
           <Label htmlFor="contact" className="flex">

--- a/components/FoundPetForm.tsx
+++ b/components/FoundPetForm.tsx
@@ -48,6 +48,8 @@ export default function FoundPetForm({ action, userId }: FoundPetFormProps) {
   const [size, setSize] = useState("medium")
   const [color, setColor] = useState("black")
   const [gender, setGender] = useState("male")
+  const [state, setState] = useState("")
+  const [city, setCity] = useState("")
 
   return (
     <form action={action} className="space-y-6 max-w-2xl mx-auto">
@@ -255,7 +257,13 @@ export default function FoundPetForm({ action, userId }: FoundPetFormProps) {
           </div>
         </div>
 
-        <SimpleLocationSelector onStateChange={() => {}} onCityChange={() => {}} required={false} />
+        <SimpleLocationSelector
+          onStateChange={setState}
+          onCityChange={setCity}
+          required={false}
+        />
+        <input type="hidden" name="state" value={state} />
+        <input type="hidden" name="city" value={city} />
 
         <div>
           <Label htmlFor="current_location">Localização atual do pet (opcional)</Label>


### PR DESCRIPTION
## Summary
- track `state` and `city` in `AdoptionPetForm`
- track `state` and `city` in `FoundPetForm`
- send location selections via hidden inputs

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b1a10a4d0832da2bbb23f1ec3ce85