### PR TITLE
Handle "other" options in pet forms

### DIFF
--- a/components/AdoptionPetForm.tsx
+++ b/components/AdoptionPetForm.tsx
@@ -32,6 +32,10 @@ export function AdoptionPetForm({ action, ongId }: AdoptionPetFormProps) {
   const [gender, setGender] = useState("Macho")
   const [size, setSize] = useState("Pequeno")
   const [color, setColor] = useState("Preto")
+  const [speciesOther, setSpeciesOther] = useState("")
+  const [genderOther, setGenderOther] = useState("")
+  const [sizeOther, setSizeOther] = useState("")
+  const [colorOther, setColorOther] = useState("")
 
   return (
     <form action={action} className="space-y-6 max-w-2xl mx-auto">
@@ -65,10 +69,12 @@ export function AdoptionPetForm({ action, ongId }: AdoptionPetFormProps) {
             </Select>
             <OtherOptionField
               isOtherSelected={species === "other"}
-              name="species_other"
+              value={speciesOther}
+              onChange={setSpeciesOther}
               label="Qual espécie?"
               required
             />
+            <input type="hidden" name="species_other" value={speciesOther} />
           </div>
 
           <div>
@@ -111,7 +117,14 @@ export function AdoptionPetForm({ action, ongId }: AdoptionPetFormProps) {
                 <SelectItem value="other">Outro</SelectItem>
               </SelectContent>
             </Select>
-            <OtherOptionField isOtherSelected={gender === "other"} name="gender_other" label="Qual gênero?" required />
+            <OtherOptionField
+              isOtherSelected={gender === "other"}
+              value={genderOther}
+              onChange={setGenderOther}
+              label="Qual gênero?"
+              required
+            />
+            <input type="hidden" name="gender_other" value={genderOther} />
           </div>
         </div>
 
@@ -131,7 +144,14 @@ export function AdoptionPetForm({ action, ongId }: AdoptionPetFormProps) {
                 <SelectItem value="other">Outro</SelectItem>
               </SelectContent>
             </Select>
-            <OtherOptionField isOtherSelected={size === "other"} name="size_other" label="Qual porte?" required />
+            <OtherOptionField
+              isOtherSelected={size === "other"}
+              value={sizeOther}
+              onChange={setSizeOther}
+              label="Qual porte?"
+              required
+            />
+            <input type="hidden" name="size_other" value={sizeOther} />
           </div>
 
           <div>
@@ -153,7 +173,14 @@ export function AdoptionPetForm({ action, ongId }: AdoptionPetFormProps) {
                 <SelectItem value="other">Outra</SelectItem>
               </SelectContent>
             </Select>
-            <OtherOptionField isOtherSelected={color === "other"} name="color_other" label="Qual cor?" required />
+            <OtherOptionField
+              isOtherSelected={color === "other"}
+              value={colorOther}
+              onChange={setColorOther}
+              label="Qual cor?"
+              required
+            />
+            <input type="hidden" name="color_other" value={colorOther} />
           </div>
         </div>
 

--- a/components/FoundPetForm.tsx
+++ b/components/FoundPetForm.tsx
@@ -48,6 +48,10 @@ export default function FoundPetForm({ action, userId }: FoundPetFormProps) {
   const [size, setSize] = useState("medium")
   const [color, setColor] = useState("black")
   const [gender, setGender] = useState("male")
+  const [speciesOther, setSpeciesOther] = useState("")
+  const [sizeOther, setSizeOther] = useState("")
+  const [colorOther, setColorOther] = useState("")
+  const [genderOther, setGenderOther] = useState("")
 
   return (
     <form action={action} className="space-y-6 max-w-2xl mx-auto">
@@ -79,10 +83,12 @@ export default function FoundPetForm({ action, userId }: FoundPetFormProps) {
             </Select>
             <OtherOptionField
               isOtherSelected={species === "other"}
-              name="species_other"
+              value={speciesOther}
+              onChange={setSpeciesOther}
               label="Qual espécie?"
               required
             />
+            <input type="hidden" name="species_other" value={speciesOther} />
           </div>
 
           <div>
@@ -108,7 +114,14 @@ export default function FoundPetForm({ action, userId }: FoundPetFormProps) {
                 ))}
               </SelectContent>
             </Select>
-            <OtherOptionField isOtherSelected={size === "other"} name="size_other" label="Qual porte?" required />
+            <OtherOptionField
+              isOtherSelected={size === "other"}
+              value={sizeOther}
+              onChange={setSizeOther}
+              label="Qual porte?"
+              required
+            />
+            <input type="hidden" name="size_other" value={sizeOther} />
           </div>
 
           <div>
@@ -130,7 +143,14 @@ export default function FoundPetForm({ action, userId }: FoundPetFormProps) {
                 <SelectItem value="other">Outra</SelectItem>
               </SelectContent>
             </Select>
-            <OtherOptionField isOtherSelected={color === "other"} name="color_other" label="Qual cor?" required />
+            <OtherOptionField
+              isOtherSelected={color === "other"}
+              value={colorOther}
+              onChange={setColorOther}
+              label="Qual cor?"
+              required
+            />
+            <input type="hidden" name="color_other" value={colorOther} />
           </div>
         </div>
 
@@ -164,7 +184,14 @@ export default function FoundPetForm({ action, userId }: FoundPetFormProps) {
               </Label>
             </div>
           </RadioGroup>
-          <OtherOptionField isOtherSelected={gender === "other"} name="gender_other" label="Qual gênero?" required />
+          <OtherOptionField
+            isOtherSelected={gender === "other"}
+            value={genderOther}
+            onChange={setGenderOther}
+            label="Qual gênero?"
+            required
+          />
+          <input type="hidden" name="gender_other" value={genderOther} />
         </div>
 
         <div className="space-y-2">

--- a/components/LostPetForm.tsx
+++ b/components/LostPetForm.tsx
@@ -33,6 +33,10 @@ export default function LostPetForm({ action, userId }: LostPetFormProps) {
   const [size, setSize] = useState("medium")
   const [color, setColor] = useState("black")
   const [gender, setGender] = useState("male")
+  const [speciesOther, setSpeciesOther] = useState("")
+  const [sizeOther, setSizeOther] = useState("")
+  const [colorOther, setColorOther] = useState("")
+  const [genderOther, setGenderOther] = useState("")
 
   return (
     <form action={action} className="space-y-6 max-w-2xl mx-auto">
@@ -63,10 +67,12 @@ export default function LostPetForm({ action, userId }: LostPetFormProps) {
             </Select>
             <OtherOptionField
               isOtherSelected={species === "other"}
-              name="species_other"
+              value={speciesOther}
+              onChange={setSpeciesOther}
               label="Qual espécie?"
               required
             />
+            <input type="hidden" name="species_other" value={speciesOther} />
           </div>
 
           <div>
@@ -96,7 +102,14 @@ export default function LostPetForm({ action, userId }: LostPetFormProps) {
                 <SelectItem value="other">Outro</SelectItem>
               </SelectContent>
             </Select>
-            <OtherOptionField isOtherSelected={size === "other"} name="size_other" label="Qual porte?" required />
+            <OtherOptionField
+              isOtherSelected={size === "other"}
+              value={sizeOther}
+              onChange={setSizeOther}
+              label="Qual porte?"
+              required
+            />
+            <input type="hidden" name="size_other" value={sizeOther} />
           </div>
 
           <div>
@@ -118,7 +131,14 @@ export default function LostPetForm({ action, userId }: LostPetFormProps) {
                 <SelectItem value="other">Outra</SelectItem>
               </SelectContent>
             </Select>
-            <OtherOptionField isOtherSelected={color === "other"} name="color_other" label="Qual cor?" required />
+            <OtherOptionField
+              isOtherSelected={color === "other"}
+              value={colorOther}
+              onChange={setColorOther}
+              label="Qual cor?"
+              required
+            />
+            <input type="hidden" name="color_other" value={colorOther} />
           </div>
         </div>
 
@@ -146,7 +166,14 @@ export default function LostPetForm({ action, userId }: LostPetFormProps) {
               </Label>
             </div>
           </RadioGroup>
-          <OtherOptionField isOtherSelected={gender === "other"} name="gender_other" label="Qual gênero?" required />
+          <OtherOptionField
+            isOtherSelected={gender === "other"}
+            value={genderOther}
+            onChange={setGenderOther}
+            label="Qual gênero?"
+            required
+          />
+          <input type="hidden" name="gender_other" value={genderOther} />
         </div>
 
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- manage local state for each additional option in `AdoptionPetForm`, `LostPetForm`, and `FoundPetForm`
- output hidden inputs to send custom values
- stop using the unsupported `name` prop on `OtherOptionField`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b1a118ddc832dae54a2bb047505c3