### PR TITLE
Add auth check to lost/found form containers

### DIFF
--- a/app/encontrados/cadastrar/form-container.tsx
+++ b/app/encontrados/cadastrar/form-container.tsx
@@ -2,6 +2,9 @@
 
 import dynamic from "next/dynamic"
 import { Loader2 } from "lucide-react"
+import { useAuth } from "@/app/auth-provider"
+import { useEffect } from "react"
+import { useRouter, usePathname } from "next/navigation"
 
 // Importação dinâmica do componente cliente com SSR desativado
 const FoundPetFormClient = dynamic(() => import("./client"), {
@@ -14,5 +17,23 @@ const FoundPetFormClient = dynamic(() => import("./client"), {
 })
 
 export default function FoundPetFormContainer() {
-  return <FoundPetFormClient />
+  const { user, isLoading, isInitialized } = useAuth()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (isInitialized && !isLoading && !user) {
+      router.replace(`/login?redirectTo=${encodeURIComponent(pathname)}`)
+    }
+  }, [isInitialized, isLoading, user, router, pathname])
+
+  if (!isInitialized || isLoading || !user) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    )
+  }
+
+  return <FoundPetFormClient userId={user.id} />
 }

--- a/app/perdidos/cadastrar/form-container.tsx
+++ b/app/perdidos/cadastrar/form-container.tsx
@@ -2,6 +2,9 @@
 
 import dynamic from "next/dynamic"
 import { Loader2 } from "lucide-react"
+import { useAuth } from "@/app/auth-provider"
+import { useEffect } from "react"
+import { useRouter, usePathname } from "next/navigation"
 
 // Importação dinâmica do componente cliente com SSR desativado
 const LostPetFormClient = dynamic(() => import("./client"), {
@@ -14,5 +17,23 @@ const LostPetFormClient = dynamic(() => import("./client"), {
 })
 
 export default function FormContainer() {
-  return <LostPetFormClient />
+  const { user, isLoading, isInitialized } = useAuth()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (isInitialized && !isLoading && !user) {
+      router.replace(`/login?redirectTo=${encodeURIComponent(pathname)}`)
+    }
+  }, [isInitialized, isLoading, user, router, pathname])
+
+  if (!isInitialized || isLoading || !user) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    )
+  }
+
+  return <LostPetFormClient userId={user.id} />
 }


### PR DESCRIPTION
## Summary
- fetch logged-in user inside lost and found form containers
- redirect to login if not authenticated
- supply user id to client form

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b1a124f40832d8e0fa5c53fcc4d34