### PR TITLE
Add minimal auth tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "node --test"
   },
   "dependencies": {
     "@hookform/resolvers": "latest",

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+// Helper to dynamically import TypeScript files when possible
+async function loadTSModule(modulePath) {
+  try {
+    return await import(modulePath);
+  } catch (err) {
+    // Node may not understand .ts extension without loader
+    // so just rethrow for visibility in test results
+    throw err;
+  }
+}
+
+test('registration success flow', async (t) => {
+  const mod = await loadTSModule('../app/actions/auth-actions.ts');
+  assert.ok(typeof mod.registerUserAndNgoAction === 'function');
+});
+
+test('login function exists', async (t) => {
+  const mod = await loadTSModule('../app/auth-provider.tsx');
+  assert.ok(typeof mod.AuthProvider === 'function');
+});
+
+test('oauth callback route exists', async (t) => {
+  const mod = await loadTSModule('../app/auth/callback/route.ts');
+  assert.ok(typeof mod.GET === 'function');
+});


### PR DESCRIPTION
## Summary
- add `npm run test` script
- create basic failing tests for auth flows

## Testing
- `npm run test` *(fails: Unknown file extension for TS modules)*

------
https://chatgpt.com/codex/tasks/task_b_686bdf6e6340832d91ec8494be0e700e