### PR TITLE
Fix redirect query param names

### DIFF
--- a/app/encontrados/edit/[id]/page.tsx
+++ b/app/encontrados/edit/[id]/page.tsx
@@ -13,7 +13,7 @@ export default async function EditFoundPetPage({ params }: { params: { id: strin
   } = await supabase.auth.getSession()
 
   if (!session) {
-    redirect("/login?redirect=/encontrados/edit/" + params.id)
+    redirect("/login?redirectTo=/encontrados/edit/" + params.id)
   }
 
   // Buscar os dados do pet encontrado na tabela unificada

--- a/app/my-pets/page.tsx
+++ b/app/my-pets/page.tsx
@@ -17,7 +17,7 @@ export default async function MyPetsPage() {
   } = await supabase.auth.getSession()
 
   if (!session) {
-    redirect("/login?redirect=/my-pets")
+    redirect("/login?redirectTo=/my-pets")
   }
 
   // Buscar os pets do usuário

--- a/app/perdidos/edit/[id]/page.tsx
+++ b/app/perdidos/edit/[id]/page.tsx
@@ -13,7 +13,7 @@ export default async function EditLostPetPage({ params }: { params: { id: string
   } = await supabase.auth.getSession()
 
   if (!session) {
-    redirect("/login?redirect=/perdidos/edit/" + params.id)
+    redirect("/login?redirectTo=/perdidos/edit/" + params.id)
   }
 
   // Buscar os dados do pet perdido

--- a/app/pets/edit/[id]/page.tsx
+++ b/app/pets/edit/[id]/page.tsx
@@ -13,7 +13,7 @@ export default async function EditPetPage({ params }: { params: { id: string } }
   } = await supabase.auth.getSession()
 
   if (!session) {
-    redirect("/login?redirect=/pets/edit/" + params.id)
+    redirect("/login?redirectTo=/pets/edit/" + params.id)
   }
 
   // Buscar os dados do pet


### PR DESCRIPTION
## Summary
- replace `?redirect=` usage with `?redirectTo=` when sending unauthenticated users to the login page

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686f26fc1cf4832d894d8befe672f45a