### PR TITLE
Fix TypeScript import path

### DIFF
--- a/scripts/ts-loader.js
+++ b/scripts/ts-loader.js
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import ts from '/root/.nvm/versions/node/v22.16.0/lib/node_modules/typescript/lib/typescript.js';
+import ts from 'typescript';
 
 export async function resolve(specifier, context, defaultResolve) {
   if (specifier.startsWith('node:')) {


### PR DESCRIPTION
## Summary
- use the `typescript` package in `ts-loader`

## Testing
- `npm test` *(fails: cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_b_687123d02ae8832d86f9a8272409b194