### PR TITLE
Replace AuthGuard with RequireAuth

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { getUserStats } from "@/lib/supabase"
 import { PawPrint, Search, Heart, Plus, Clock, ArrowRight, BookOpen } from "lucide-react"
-import AuthGuard from "@/components/auth-guard"
+import RequireAuth from "@/components/require-auth"
 
 type UserStats = {
   adoptionCount: number
@@ -307,8 +307,8 @@ function DashboardContent() {
 
 export default function DashboardPage() {
   return (
-    <AuthGuard>
+    <RequireAuth>
       <DashboardContent />
-    </AuthGuard>
+    </RequireAuth>
   )
 }


### PR DESCRIPTION
## Summary
- switch to `RequireAuth` wrapper in the dashboard page

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_b_6873f89057b4832dba87c5d5504f7a07