### PR TITLE
use fallback user id when creating pets

### DIFF
--- a/app/actions/found-pet-actions.ts
+++ b/app/actions/found-pet-actions.ts
@@ -43,8 +43,8 @@ export async function createFoundPet(prevState: any, formData: FormData) {
   const {
     data: { user },
   } = await supabase.auth.getUser()
-
-  if (!user) {
+  const userId = user?.id || (formData.get("user_id") as string | null)
+  if (!userId) {
     return { success: false, error: "Usuário não autenticado. Faça login para continuar." }
   }
 
@@ -103,7 +103,7 @@ export async function createFoundPet(prevState: any, formData: FormData) {
       slug,
       category: "found",
       status: "sheltered",
-      user_id: user.id,
+      user_id: userId,
     })
     .select()
     .single()

--- a/app/actions/pet-actions.ts
+++ b/app/actions/pet-actions.ts
@@ -46,8 +46,8 @@ export async function createLostPet(prevState: any, formData: FormData) {
   const {
     data: { user },
   } = await supabase.auth.getUser()
-
-  if (!user) {
+  const userId = user?.id || (formData.get("user_id") as string | null)
+  if (!userId) {
     return { success: false, error: "Usuário não autenticado. Faça login para continuar." }
   }
 
@@ -106,7 +106,7 @@ export async function createLostPet(prevState: any, formData: FormData) {
       slug,
       category: "lost",
       status: "missing",
-      user_id: user.id,
+      user_id: userId,
     })
     .select()
     .single()


### PR DESCRIPTION
## Summary
- fallback to `user_id` from formData when user isn't authenticated
- insert pets with the derived user ID
- verify forms still send the user ID

## Testing
- `pnpm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_b_6875ad0d999c832da0d3ae133edf0b22