### PR TITLE
Remove debug logs from adoption actions

### DIFF
--- a/app/actions/pet-actions.ts
+++ b/app/actions/pet-actions.ts
@@ -129,12 +129,9 @@ export async function createLostPet(prevState: any, formData: FormData) {
 
 // Função para cadastrar um pet para adoção - VERSÃO CLIENT-SIDE
 export async function createAdoptionPetClientSide(petData: PetFormUI, userId: string) {
-  console.log("createAdoptionPetClientSide chamado com:", petData, "userId:", userId)
-
   try {
     // Usar createClient com cookies para manter a sessão
     const supabase = createClient()
-    console.log("Cliente Supabase criado")
 
     // Verificar se é uma edição ou criação
     const isEditing = petData.is_editing === true
@@ -200,11 +197,7 @@ export async function createAdoptionPetClientSide(petData: PetFormUI, userId: st
       updated_at: new Date().toISOString(),
     }
 
-    console.log("Inserindo novo pet:", newPet)
-
     const { data: insertedPet, error: insertError } = await supabase.from("pets").insert(newPet).select().single()
-
-    console.log("Resultado da inserção:", insertedPet ? "Sucesso" : "Falha", insertError || "")
 
     if (insertError) {
       console.error("Erro ao cadastrar pet:", insertError)


### PR DESCRIPTION
## Summary
- delete leftover console.log statements in `createAdoptionPetClientSide`

## Testing
- `npm test` *(fails: cannot find 'typescript')*

------
https://chatgpt.com/codex/tasks/task_b_687669339a9c832d8073d748130a4e7f