### PR TITLE
Fix missing lucide Handshake icon

### DIFF
--- a/components/admin-navigation.tsx
+++ b/components/admin-navigation.tsx
@@ -13,10 +13,10 @@ import {
   Settings,
   ShieldCheck,
   BookOpen,
-  Handshake,
   Search,
   AlertTriangle,
 } from "lucide-react"
+import { Handshake } from "@/components/icons/handshake"
 
 const adminNavItems = [
   {

--- a/components/icons/handshake.tsx
+++ b/components/icons/handshake.tsx
@@ -1,0 +1,21 @@
+import { LucideProps } from "lucide-react"
+
+export function Handshake(props: LucideProps) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M2 15l5 5 4-4 4 4 5-5" />
+      <path d="M6 15V9l6-3 6 3v6" />
+      <path d="M8 10l4 4 4-4" />
+    </svg>
+  )
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -18,9 +18,9 @@ import {
   LogOut,
   User,
   Shield,
-  Handshake,
   BookOpen,
 } from "lucide-react"
+import { Handshake } from "@/components/icons/handshake"
 import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/app/auth-provider"


### PR DESCRIPTION
## Summary
- add custom Handshake icon component
- use the custom icon in the navbar and admin navigation

## Testing
- `npm test` *(fails: cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_b_68766f29bda8832dbb71b31fad3cb94b