### PR TITLE
Update links to new adoption route

### DIFF
--- a/app/adocao/AdocaoClientPage.tsx
+++ b/app/adocao/AdocaoClientPage.tsx
@@ -116,7 +116,7 @@ export default function AdocaoClientPage({ initialPets, pagination, initialFilte
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">
         <h1 className="text-3xl font-bold">Pets para Adoção</h1>
         <Button asChild>
-          <Link href="/adocao/cadastrar">
+          <Link href="/cadastrar-pet-adocao">
             <Plus className="mr-2 h-4 w-4" />
             Cadastrar Pet para Adoção
           </Link>
@@ -167,7 +167,7 @@ export default function AdocaoClientPage({ initialPets, pagination, initialFilte
                 Não encontramos nenhum pet para adoção com os filtros selecionados.
               </p>
               <Button asChild>
-                <Link href="/adocao/cadastrar">Cadastrar Pet para Adoção</Link>
+                <Link href="/cadastrar-pet-adocao">Cadastrar Pet para Adoção</Link>
               </Button>
             </div>
           )}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -121,7 +121,7 @@ function DashboardContent() {
         </div>
         <div className="mt-4 md:mt-0 flex gap-2">
           <Button asChild>
-            <Link href="/adocao/cadastrar">
+            <Link href="/cadastrar-pet-adocao">
               <Plus className="mr-2 h-4 w-4" />
               Cadastrar Pet para Adoção
             </Link>
@@ -243,7 +243,7 @@ function DashboardContent() {
                 <div className="text-center py-8 text-muted-foreground">
                   <p>Você ainda não cadastrou nenhum pet.</p>
                   <Button variant="outline" className="mt-4" asChild>
-                    <Link href="/adocao/cadastrar">Cadastrar Pet</Link>
+                    <Link href="/cadastrar-pet-adocao">Cadastrar Pet</Link>
                   </Button>
                 </div>
               )}
@@ -268,7 +268,7 @@ function DashboardContent() {
             </CardHeader>
             <CardContent className="space-y-4">
               <Button className="w-full justify-start" asChild>
-                <Link href="/adocao/cadastrar">
+                <Link href="/cadastrar-pet-adocao">
                   <Heart className="mr-2 h-4 w-4" />
                   Cadastrar Pet para Adoção
                 </Link>

--- a/app/my-pets/page.tsx
+++ b/app/my-pets/page.tsx
@@ -32,7 +32,7 @@ export default async function MyPetsPage() {
         </div>
         <div className="flex flex-wrap gap-2">
           <Button asChild>
-            <Link href="/adocao/cadastrar">
+            <Link href="/cadastrar-pet-adocao">
               <PlusCircle className="mr-2 h-4 w-4" />
               Cadastrar para Adoção
             </Link>
@@ -84,7 +84,7 @@ export default async function MyPetsPage() {
             <div className="text-center py-12">
               <p className="text-muted-foreground mb-4">Você ainda não cadastrou nenhum pet para adoção.</p>
               <Button asChild>
-                <Link href="/adocao/cadastrar">
+                <Link href="/cadastrar-pet-adocao">
                   <PlusCircle className="mr-2 h-4 w-4" />
                   Cadastrar Pet para Adoção
                 </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -87,7 +87,7 @@ export default async function Home() {
                 Ainda não há pets para adoção. Seja o primeiro a cadastrar um pet!
               </p>
               <Button className="mt-4" asChild>
-                <Link href="/adocao/cadastrar">Cadastrar Pet para Adoção</Link>
+                <Link href="/cadastrar-pet-adocao">Cadastrar Pet para Adoção</Link>
               </Button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- update all references to `/adocao/cadastrar` to use `/cadastrar-pet-adocao`

## Testing
- `npm test` *(fails: cannot find package 'typescript')*
- `pnpm install` *(fails: unable to fetch packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6876dc07f1d0832db98349a293847f11